### PR TITLE
ARVN or VC vehicles Zeus'd or editor'd into the game always use US skins

### DIFF
--- a/mission/description.ext
+++ b/mission/description.ext
@@ -70,8 +70,6 @@ wreckLimit = 2;
 wreckRemovalMinTime = 60;
 wreckRemovalMaxTime = 360;
 
-disableRandomization[] = {"All"};
-
 showHUD[] =
 {
 	true,	// Scripted HUD (same as showHUD command)


### PR DESCRIPTION
The disable randomization param prevents vehicles from using anything other than their base skin.