### PR TITLE
Add master arm type system for apc

### DIFF
--- a/mission/description.ext
+++ b/mission/description.ext
@@ -70,8 +70,6 @@ wreckLimit = 2;
 wreckRemovalMinTime = 60;
 wreckRemovalMaxTime = 360;
 
-disableRandomization[] = {"All"};
-
 showHUD[] =
 {
 	true,	// Scripted HUD (same as showHUD command)

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -228,7 +228,16 @@ if hasInterface then
         true,
         true,
         "",
-        "local (vehicle _this) && {!(vehicle _this isKindOf 'Air' || vehicle _this isKindOf 'Man') && {speed (vehicle _this) <= 5 && {(driver vehicle _this) isEqualTo _this && {vn_fnc_masterarm_action_objects findif {(vehicle _this distance _x) < 25} > -1}}}}",
+        toString {
+            private _vehicle = vehicle _this;
+            local _vehicle && {
+                !(_vehicle isKindOf 'Air' || _vehicle isKindOf 'Man') && {
+                    speed _vehicle <= 5 && {
+                        driver _vehicle == _this && {vn_fnc_masterarm_action_objects findif {(_vehicle distance _x) < 25} > -1}
+                    }
+                }
+            }
+        },
         25
     ];
 


### PR DESCRIPTION
Currently not able to supply from this master arm menu except for certain edge cases. Any cases where resupply is possible will be fixed with the next DLC update. The only exception to this is that by bringing the appropriate supply vehicles forward you will be able to use them in conjunction with this master arm window. This is an intended feature and will not be removed.

To be merged with https://github.com/Savage-Game-Design/Paradigm/pull/1. Currently blocked by https://github.com/Savage-Game-Design/Mike-Force/pull/148.