### PR TITLE
Use create vehicle safely function for site spawning.

### DIFF
--- a/mission/functions/systems/sites/fn_create_aa_emplacement.sqf
+++ b/mission/functions/systems/sites/fn_create_aa_emplacement.sqf
@@ -20,7 +20,7 @@ params ["_position", ["_style", "heavy"]];
 
 private _aaGun	= ["vn_o_nva_static_dshkm_high_02", "vn_o_nva_static_zpu4"] select (_style == "heavy");
 
-private _crewedAAGun = [[_aaGun, _position] call para_g_fnc_create_vehicle, [], grpNull];
+private _crewedAAGun = [[_aaGun, _position] call para_g_fnc_create_vehicle_safely, [], grpNull];
 
 private _vehicles = [_crewedAAGun select 0];
 private _units = _crewedAAGun select 1;

--- a/mission/functions/systems/sites/fn_create_mortar.sqf
+++ b/mission/functions/systems/sites/fn_create_mortar.sqf
@@ -18,7 +18,7 @@
 
 params ["_position"];
 
-private _mortar = [[selectRandom vehicles_vc_mortars, _position] call para_g_fnc_create_vehicle, [], grpNull];
+private _mortar = [[selectRandom vehicles_vc_mortars, _position] call para_g_fnc_create_vehicle_safely, [], grpNull];
 
 private _vehicles = [_mortar select 0];
 private _units = _mortar select 1;


### PR DESCRIPTION
Only runs once at mission start, should have negligible performance impact.