### PR TITLE
added params for RTO firesupport danger close distance

### DIFF
--- a/mission/config/artillery.hpp
+++ b/mission/config/artillery.hpp
@@ -7,7 +7,7 @@ class vn_artillery_settings
         availability[] = {0, 1, 1, 0, 0};
         unit_trait_required = 1;
 	      // Distance from the edge of a blacklisted marker that a artillery/aircraft cannot be called in.
-	      danger_distance = ["danger_close_distance", 150] call BIS_fnc_getParamValue;
+	      danger_distance = "['danger_close_distance', 150] call BIS_fnc_getParamValue";
         radio_backpacks[] = {"vn_o_pack_t884_01", "vn_o_pack_t884_ish54_01_pl", "vn_o_pack_t884_m1_01_pl", "vn_o_pack_t884_m38_01_pl", "vn_o_pack_t884_ppsh_01_pl", "vn_b_pack_prc77_01_m16_pl", "vn_b_pack_03_m3a1_pl", "vn_b_pack_03_xm177_pl", "vn_b_pack_03_type56_pl", "vn_b_pack_03", "vn_b_pack_prc77_01", "vn_b_pack_trp_04", "vn_b_pack_trp_04_02", "vn_b_pack_03", "vn_b_pack_03_02", "vn_b_pack_lw_06"};
         radio_vehicles[] = {"vn_b_boat_05_01", "vn_b_wheeled_m54_03", "vn_b_wheeled_m151_01", "vn_b_wheeled_m54_02", "vn_b_wheeled_m54_01", "vn_b_wheeled_m54_mg_02", "vn_i_air_ch34_02_01", "vn_i_air_ch34_01_02", "vn_i_air_ch34_02_02"};
         player_types[] = {"vn_b_men_sog_05", "vn_b_men_sog_17", "vn_b_men_army_08", "vn_o_men_nva_dc_13", "vn_o_men_nva_65_27", "vn_o_men_nva_65_13", "vn_o_men_nva_27", "vn_o_men_nva_13", "vn_o_men_nva_marine_13", "vn_o_men_nva_navy_13", "vn_o_men_vc_local_27", "vn_o_men_vc_local_13", "vn_o_men_vc_regional_13"};

--- a/mission/config/artillery.hpp
+++ b/mission/config/artillery.hpp
@@ -7,7 +7,7 @@ class vn_artillery_settings
         availability[] = {0, 1, 1, 0, 0};
         unit_trait_required = 1;
 	      // Distance from the edge of a blacklisted marker that a artillery/aircraft cannot be called in.
-	      danger_distance = 150;
+	      danger_distance = ["danger_close_distance", 150] call BIS_fnc_getParamValue;
         radio_backpacks[] = {"vn_o_pack_t884_01", "vn_o_pack_t884_ish54_01_pl", "vn_o_pack_t884_m1_01_pl", "vn_o_pack_t884_m38_01_pl", "vn_o_pack_t884_ppsh_01_pl", "vn_b_pack_prc77_01_m16_pl", "vn_b_pack_03_m3a1_pl", "vn_b_pack_03_xm177_pl", "vn_b_pack_03_type56_pl", "vn_b_pack_03", "vn_b_pack_prc77_01", "vn_b_pack_trp_04", "vn_b_pack_trp_04_02", "vn_b_pack_03", "vn_b_pack_03_02", "vn_b_pack_lw_06"};
         radio_vehicles[] = {"vn_b_boat_05_01", "vn_b_wheeled_m54_03", "vn_b_wheeled_m151_01", "vn_b_wheeled_m54_02", "vn_b_wheeled_m54_01", "vn_b_wheeled_m54_mg_02", "vn_i_air_ch34_02_01", "vn_i_air_ch34_01_02", "vn_i_air_ch34_02_02"};
         player_types[] = {"vn_b_men_sog_05", "vn_b_men_sog_17", "vn_b_men_army_08", "vn_o_men_nva_dc_13", "vn_o_men_nva_65_27", "vn_o_men_nva_65_13", "vn_o_men_nva_27", "vn_o_men_nva_13", "vn_o_men_nva_marine_13", "vn_o_men_nva_navy_13", "vn_o_men_vc_local_27", "vn_o_men_vc_local_13", "vn_o_men_vc_regional_13"};

--- a/mission/config/params.hpp
+++ b/mission/config/params.hpp
@@ -334,6 +334,22 @@ class enable_air_support_desc
     default = 1;
 };
 
+class danger_close_distance
+{
+    title = $STR_vn_mf_param_danger_close;
+    values[] = {0, 25, 50, 75, 100, 150, 200};
+    texts[] = {"0 meters", "25 meters", "50 meters", "75 meters", "100 meters", "150 meters", "200 meters"};
+    default = 150;
+};
+
+class danger_close_distance_desc
+{
+    title = $STR_vn_mf_param_danger_close_disc;
+    values[] = {""};
+    texts[] = {""};
+    default = "";
+};
+
 class Spacer15 : Spacer1 {};
 
 class medical_header

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -955,6 +955,12 @@
         <Original>==== Enable RTO Artillery Support ====</Original>
         <English>==== Enable RTO Artillery Support ====</English>
       </Key>
+      <Key ID="STR_vn_mf_param_danger_close">
+        <Original>==== RTO Firesupport Danger Close Distance ====</Original>
+      </Key>
+      <Key ID="STR_vn_mf_param_danger_close_disc">
+        <Original>The minimum distance to friendlies that RTO firesupport can be called in</Original>
+      </Key>
       <Key ID="STR_vn_mf_param_enable_stamina">
         <Original>==== Enable Stamina ====</Original>
         <English>==== Enable Stamina ====</English>


### PR DESCRIPTION
I added a param for the RTO firesupport danger-close distance. We use it in a playthrough to be able to send them closer when friendlies are in bunkers or other fortifications and need fire support within 50m to avoid being overrun. 

I saw someone else here requested it: #163 and thought I might as well make a PR in case it was something you would be interested in. 