### PR TITLE
VehAssetManager: Bugfix for map marker text conflicts.

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_marker_create.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_marker_create.sqf
@@ -45,7 +45,7 @@ private _textGenerator = [
 	}
 ];
 
-private _markerName = format ["marker_%1", _spawnPoint get "id"];
+private _markerName = format ["vn_mf_veh_asset_marker_%1", _spawnPoint get "id"];
 [_markerName, getPos _vehicle, _textGenerator] call para_g_fnc_create_localized_marker;
 
 _markerName setMarkerType "mil_marker";


### PR DESCRIPTION
The vehicle asset manager system created vehicle map marks with a name a la `marker_1`.

Unfortunately, Eden Editor defaults to the same default marker naming convention i.e. `marker_1`.

Failing to rename Eden Editor map marks from the default can cause conflicts with the vehicle asset manager system, where idle vehicles on map are shown as "P1" or "Rearm/Repair" or whatever the Eden map marker text refers to (see screenshot).

Gets pretty tedious when there are a lot of eden map marks to edit.

Fixed by prefixing vehicle asset manage map marker names with more specific name prefix. (Saves people an extra job when putting down map marks in the editor).

![320218624-23362ff7-0d4c-4f07-840c-89d2da599104](https://github.com/Savage-Game-Design/Mike-Force/assets/11841332/22294067-6844-4cce-ad67-3fc70ba1d190)
