### PR TITLE
VehicleLocking: Allow locking of static weapons to a specific team.

### DIFF
--- a/mission/functions/systems/vehicle_locking/fn_player_can_enter_vehicle.sqf
+++ b/mission/functions/systems/vehicle_locking/fn_player_can_enter_vehicle.sqf
@@ -4,7 +4,7 @@
 	Public: No
 
 	Description:
-		Check if the player can enter the vehicle.
+		Check if the player can enter the vehicle (or static weapon).
 
 	Parameter(s):
 	_player - Player that wants to enter [Object]
@@ -18,17 +18,32 @@
 */
 
 
-params ["_player", "_role", "_vehicle"];
+private _fnc_player_is_authorized = {
+	params ["_vehicle", "_player"];
 
-private _isCopilot = (getNumber ([_vehicle, _vehicle unitTurret _player] call BIS_fnc_turretConfig >> "isCopilot") > 0);
-private _playerGroup = _player getVariable ["vn_mf_db_player_group", "FAILED"];
-
-if (_role == "driver" || _isCopilot) exitWith {
 	private _teamsVehicleIsLockedTo = _vehicle getVariable ["teamLock", []];
+	private _playerGroup = _player getVariable ["vn_mf_db_player_group", "FAILED"];
+
 	if (_teamsVehicleIsLockedTo isEqualTo [] || _playerGroup in _teamsVehicleIsLockedTo) exitWith {
 		true
 	};
+
 	false
+};
+
+
+params ["_player", "_role", "_vehicle"];
+
+if (_vehicle isKindOf "StaticWeapon") exitWith {
+	[_vehicle, _player] call _fnc_player_is_authorized
+};
+
+private _isCopilot = (getNumber ([_vehicle, _vehicle unitTurret _player] call BIS_fnc_turretConfig >> "isCopilot") > 0);
+
+// allows passengers into vehicles
+
+if (_role == "driver" || _isCoPilot) exitWith {
+	[_vehicle, _player] call _fnc_player_is_authorized
 };
 
 true


### PR DESCRIPTION
Locking script only applied to vehicles with a driver / co-pilot position -- StaticWeapon objects don't have a driver or a co-pilot.

With vanilla config settings, this should only affect the locking of the `m101` assets for ACAV
```
//Howitzer
class vn_b_army_static_m101_02 : acav {};
class vn_b_sf_static_m101_02 : acav {};
```

Allows server owners to include any static weapon in the vehicle locking config.

Note -- may well be possible to go through the same config lookup as the existing `isCopilot` check but for `isGunner` instead, but I went with the simple, happy path route.