### PR TITLE
VehSpawner: Fix Advanced Logistics blocking static weapon respawns.

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_process_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_process_spawn_point.sqf
@@ -54,6 +54,25 @@ if (!alive _vehicle && !((_spawnPoint get "status" get "state") in ["RESPAWNING"
 	};
 };
 
+// advanced logistics system check
+// when vehicle container is destroyed, this forces statics to destroyed too
+if (
+        _vehicle getVariable ["log_inventory_loaded", false]
+        && !alive (_vehicle getVariable ["log_inventory_loaded_vehicle", objNull])
+        && !((_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING"])
+) then {
+        if (_respawnType == "WRECK") exitWith {
+		// TODO: unload the static weapons nearby?
+                deleteVehicle _vehicle;
+                [_spawnPoint] call vn_mf_fnc_veh_asset_set_wrecked;
+        };
+
+        if (_respawnType == "RESPAWN") exitWith {
+                [_spawnPoint, _settings get "time"] call vn_mf_fnc_veh_asset_set_respawning;
+        };
+};
+
+
 if (!canMove _vehicle) then {
 	if ((_spawnPoint get "status" get "state") in ["ACTIVE", "IDLE"]) then {
 		[_spawnPoint] call vn_mf_fnc_veh_asset_set_disabled;


### PR DESCRIPTION
When an advanced logistics container vehicle is destroyed, static weapons created by the vehicle spawner (vehicle asset manager) system can be blocked from respawning. 

The static weapon object is still alive, hidden and attached to the player who loaded it into the now destroyed container vehicle... meaning the static weapon will not respawn at the vehicle spawn point.

This change fixes the block on spawning by checking if the spawn point's `_currentVehicle` was loaded into a container vehicle with advanced logistics, and whether the container vehicle is still alive. If not, force respawn of `_currentVehicle`.

### additional

`_vehicle getVariable ["log_inventory_loaded", false]` should hopefully double up as a check for whether the advanced logistics module is enabled -- variable should not be set otherwise. 

Would be nice to unload static weapons from a destroyed adv-log container vehicle if they are configured for WRECK. but that's more complex.

Tested this pretty thoroughly, not encountered any issues. 