### PR TITLE
Sites: Stop zone soft lock when a player 'steals' site objects.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -223,6 +223,7 @@ class CfgFunctions
 			class sites_init {};
 			class sites_load {};
 			class sites_teardown_site {};
+			class sites_check_standard_site_completed {};
 
 			//Specific types of site
 			class sites_create_aa_site {};

--- a/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
+++ b/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
@@ -74,4 +74,4 @@ private _objectsInArea = _objectsToCheck inAreaArray [
 	false
 ];
 
-_objectsInArea findIf {alive _x && {!(_x getVariable ["log_inventory_loaded", false])}} == -1;
+_objectsInArea findIf {alive _x} == -1;

--- a/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
+++ b/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
@@ -74,4 +74,4 @@ private _objectsInArea = _objectsToCheck inAreaArray [
 	false
 ];
 
-_objectsInArea findIf {alive _x && !(_x getVariable ["log_inventory_loaded", false])} == -1;
+_objectsInArea findIf {alive _x && {!(_x getVariable ["log_inventory_loaded", false])}} == -1;

--- a/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
+++ b/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
@@ -1,0 +1,76 @@
+/*
+    File: fn_sites_check_standard_site_completed.sqf
+    Author: @dijksterhuis
+    Public: Yes
+    
+    Description:
+
+        Standardised check for whether a site should be considered completed or not.
+
+        'Standardised' here basically means typical Mike Force sites where players need
+        to clear/destroy/spike certain objects to complete that site and progress.
+
+        The check also covers the case where a player has picked up a mortar/ZPU object
+        and walked away from the site with the advanced logistics module. Or some 'arma'
+        happened, yeeting the object away from the site.
+
+    Parameter(s):
+
+        * _objectsToCheck           -- [ARRAY]: the objects in the site whose presence
+                                       needs to be checked
+        * _centrepointObjectOrPos   -- [OBJECT/POSITION]: centrepoint for the area search.
+                                       either an object (usually the _siteStore simple
+                                       object), or a position array
+        * _checkRadius              -- [NUMBER]: how far away from the site do we need to
+                                       check for the objects before considering them
+                                       "gone".
+        * _checkIsRectangle         -- [BOOL]: whether the search area is an ellipse
+                                       (default) or rectangular
+    
+    Returns:
+
+        true if site is completed, false otherwise
+    
+    Example(s):
+
+        // circular area search using _storeStore object as centre
+        [
+            _siteStore getVariable ["aaGuns", []],
+            _siteStore,
+            20
+        ] call vn_mf_fnc_sites_check_standard_site_completed;
+
+        // circular area search using some other position as centre
+        [
+            _siteStore getVariable ["staticMgs", []],
+            [0, 0, 0],
+            10,
+            false
+        ] call vn_mf_fnc_sites_check_standard_site_completed;
+
+        // rectangular area search
+        [
+            _siteStore getVariable ["mortars", []],
+            _siteStore,
+            5,
+            true
+        ] call vn_mf_fnc_sites_check_standard_site_completed;
+
+*/
+
+params [
+	"_objectsToCheck",
+	"_centrepointObjectOrPos",
+	"_checkRadius",
+	["_checkIsRectangle", false]
+];
+
+private _objectsInArea = _objectsToCheck inAreaArray [
+	_centrepointObjectOrPos,
+	_checkRadius,
+	_checkRadius,
+	0,
+	false
+];
+
+_objectsInArea findIf {alive _x} == -1;

--- a/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
+++ b/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
@@ -10,9 +10,10 @@
         'Standardised' here basically means typical Mike Force sites where players need
         to clear/destroy/spike certain objects to complete that site and progress.
 
-        The check also covers the case where a player has picked up a mortar/ZPU object
-        and walked away from the site with the advanced logistics module. Or some 'arma'
-        happened, yeeting the object away from the site.
+        The check also covers the cases where
+            * some 'arma' has happened, yeeting the object far away from the site
+            * a player has picked up a site object and walked away from the site
+            * a player has loaded a site object as vehicle cargo
 
     Parameter(s):
 
@@ -73,4 +74,4 @@ private _objectsInArea = _objectsToCheck inAreaArray [
 	false
 ];
 
-_objectsInArea findIf {alive _x} == -1;
+_objectsInArea findIf {alive _x && !(_x getVariable ["log_inventory_loaded", false])} == -1;

--- a/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
+++ b/mission/functions/systems/sites/fn_sites_check_standard_site_completed.sqf
@@ -74,4 +74,4 @@ private _objectsInArea = _objectsToCheck inAreaArray [
 	false
 ];
 
-_objectsInArea findIf {alive _x} == -1;
+_objectsInArea findIf {alive _x} == -1

--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -88,8 +88,21 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "aaGuns" findIf {alive _x} == -1)
+
+                private _pos = getPos _siteStore;
+                private _objects = _siteStore getVariable ["aaGuns", []];
+
+                /*
+                Teardown when all guns are either
+                - destroyed
+                - no longer with 20m radius of site centre point
+                */
+
+                private _objectsAreAliveInRadius = _objects findIf {
+                        (alive _x) && (count ([_x] inAreaArray [_pos, 20, 20, 0, false]) > 0)
+                };
+
+                _objectsAreAliveInRadius == -1
 	},
 	//Teardown code
 	{

--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -67,6 +67,10 @@ params ["_pos"];
 		private _objectives = [];
 		{
 			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
+			// site objects being placed in a vehicle's logistics inventory
+			// can result in strange side-effects / edge cases, including
+			// soft-locked sites and objects being deleted in front of players.
+			_x setVariable ["vn_log_enablePickup", false];
 		} forEach _guns;
 		_objectives pushBack ([_spawnPos, 2, 3] call para_s_fnc_ai_obj_request_defend);
 

--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -88,21 +88,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-
-                private _pos = getPos _siteStore;
-                private _objects = _siteStore getVariable ["aaGuns", []];
-
-                /*
-                Teardown when all guns are either
-                - destroyed
-                - no longer with 20m radius of site centre point
-                */
-
-                private _objectsAreAliveInRadius = _objects findIf {
-                        (alive _x) && (count ([_x] inAreaArray [_pos, 20, 20, 0, false]) > 0)
-                };
-
-                _objectsAreAliveInRadius == -1
+		[
+			_siteStore getVariable ["aaGuns", []],
+			_siteStore,
+			20
+		] call vn_mf_fnc_sites_check_standard_site_completed;
 	},
 	//Teardown code
 	{

--- a/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
@@ -61,6 +61,10 @@ params ["_pos"];
 		private _objectives = [];
 		{
 			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
+			// site objects being placed in a vehicle's logistics inventory
+			// can result in strange side-effects / edge cases, including
+			// soft-locked sites and objects being deleted in front of players.
+			_x setVariable ["vn_log_enablePickup", false];
 		} forEach _mortars;
 		_objectives pushBack ([_spawnPos, 1, 2] call para_s_fnc_ai_obj_request_defend);
 

--- a/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
@@ -81,21 +81,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-
-		private _pos = getPos _siteStore;
-		private _objects = _siteStore getVariable ["mortars", []];
-
-		/*
-		Teardown when all guns are either
-		- destroyed
-		- no longer with 20m radius of site cetnre point
-		*/
-
-		private _objectsAreAliveInRadius = _objects findIf {
-			(alive _x) && (count ([_x] inAreaArray [_pos, 20, 20, 0, false]) > 0)
-		};
-
-		_objectsAreAliveInRadius == -1
+		[
+			_siteStore getVariable ["mortars", []],
+			_siteStore,
+			20
+		] call vn_mf_fnc_sites_check_standard_site_completed;
 	},
 	//Teardown code
 	{

--- a/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
@@ -81,8 +81,21 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "mortars" findIf {alive _x} == -1)
+
+		private _pos = getPos _siteStore;
+		private _objects = _siteStore getVariable ["mortars", []];
+
+		/*
+		Teardown when all guns are either
+		- destroyed
+		- no longer with 20m radius of site cetnre point
+		*/
+
+		private _objectsAreAliveInRadius = _objects findIf {
+			(alive _x) && (count ([_x] inAreaArray [_pos, 20, 20, 0, false]) > 0)
+		};
+
+		_objectsAreAliveInRadius == -1
 	},
 	//Teardown code
 	{

--- a/mission/functions/systems/sites/fn_sites_create_hq.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_hq.sqf
@@ -39,6 +39,11 @@ params ["_pos"];
 		private _hqObjects = [_spawnPos] call vn_mf_fnc_create_hq_buildings;
 		private _objectsToDestroy = _hqObjects select {_x isKindOf "land_vn_pavn_ammo"};
 
+		// site objects being placed in a vehicle's logistics inventory
+		// can result in strange side-effects / edge cases, including
+		// soft-locked sites and objects being deleted in front of players.
+		_objectsToDestroy apply {_x setVariable ["vn_log_enablePickup", false]};
+
 		{
 			[_x, true] call para_s_fnc_enable_dynamic_sim;
 		} forEach _hqObjects;

--- a/mission/functions/systems/sites/fn_sites_create_hq.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_hq.sqf
@@ -84,22 +84,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-
-		private _pos = getPos _siteStore;
-		private _radius = _siteStore getVariable ["siteRadius", 50];
-		private _objects = _siteStore getVariable ["objectsToDestroy", []];
-
-		/*
-		Teardown when all ammo crates are either
-		- destroyed
-		- no longer within radius of site
-		*/
-
-		private _objectsAreAliveInRadius = _objects findIf {
-			(alive _x) && (count ([_x] inAreaArray [_pos, _, _radius, 0, false]) > 0)
-		};
-
-		_objectsAreAliveInRadius == -1
+		[
+			_siteStore getVariable ["objectsToDestroy", []],
+			_siteStore,
+			_siteStore getVariable ["siteRadius", 50]
+		] call vn_mf_fnc_sites_check_standard_site_completed;
 	},
 	//Teardown code
 	{

--- a/mission/functions/systems/sites/fn_sites_create_hq.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_hq.sqf
@@ -28,10 +28,13 @@ params ["_pos"];
 		private _sitePos = getPos _siteStore;
 		private _spawnPos = _sitePos;
 
+		private _radius = 50;
+		_siteStore setVariable ["siteRadius", _radius];
+
 		//Hide all nearby terrain objects.
 		{
 			_x hideObjectGlobal true;
-		} forEach (nearestTerrainObjects [_spawnPos, ["TREE", "BUSH", "SMALL TREE", "ROCK", "ROCKS"], 50, false, true]);
+		} forEach (nearestTerrainObjects [_spawnPos, ["TREE", "BUSH", "SMALL TREE", "ROCK", "ROCKS"], _radius, false, true]);
 
 		private _hqObjects = [_spawnPos] call vn_mf_fnc_create_hq_buildings;
 		private _objectsToDestroy = _hqObjects select {_x isKindOf "land_vn_pavn_ammo"};
@@ -81,8 +84,22 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+
+		private _pos = getPos _siteStore;
+		private _radius = _siteStore getVariable ["siteRadius", 50];
+		private _objects = _siteStore getVariable ["objectsToDestroy", []];
+
+		/*
+		Teardown when all ammo crates are either
+		- destroyed
+		- no longer within radius of site
+		*/
+
+		private _objectsAreAliveInRadius = _objects findIf {
+			(alive _x) && (count ([_x] inAreaArray [_pos, _, _radius, 0, false]) > 0)
+		};
+
+		_objectsAreAliveInRadius == -1
 	},
 	//Teardown code
 	{


### PR DESCRIPTION
Some newer players think it's a good idea to steal PAVN mortars/zpus etc and take them back to their FOB.

Repurposing enemy assets is a legit strategy, but it causes a zone to become soft locked as the site will not complete unless the objects are destroyed (not alive).

----

There's also a case where loading the mortar/zpu into a vehicle with advanced logistics will cause a soft lock. This change also solves that case -- don't allow critical site objects to be loaded into vehicles.

I can't quite remember what happens if the player dies within the search radius while the object is still attached to their character model via advanced logistics. My intuition tells me it would not being a good thing.

I can include some of the logic from #178 to cover that additional case.