### PR TITLE
Teams: Fix debug player spawn after deleting team config class.

### DIFF
--- a/mission/functions/core/teams/fn_change_team.sqf
+++ b/mission/functions/core/teams/fn_change_team.sqf
@@ -21,6 +21,16 @@ params ["_player", "_team", ["_fullTeamBehaviour", "ABORT"]];
 
 private _currentTeam = _player getVariable ["vn_mf_db_player_group", "FAILED"];
 
+// cover the case where a custom player team has been removed from the teams subconfig
+// by putting the player into the MikeForce team.
+private _teams = (
+	"isClass(_x)" configClasses (missionConfigFile >> "gamemode" >> "teams")
+) apply {configName _x};
+
+if !(_team in _teams) then {
+	_team = "MikeForce";
+};
+
 if (_currentTeam isEqualTo _team) exitWith { false };
 
 if (vn_mf_duty_officers inAreaArray [getPos _player, 20, 20, 0, false, 20] isEqualTo []) exitWith {


### PR DESCRIPTION
Reproduction:

0. Mission has a `TeamX` class in the `teams.hpp` config
1. Player joins a server and joins `TeamX`
2. Player leaves the server
3. Mission is updated with `TeamX` deleted from the `teams.hpp` config
4. On next server join, player will spawn in debug, as the team does not exist and there's no associated respawn point.

Fixed by checking if the player's current team exists in the config. If not, chuck them into `MikeForce` team as a fallback.

Could also be fixed manually by server owners fiddling around with player data in the server's `profileNamespace`. But that's a bit of a pain to do.
