### PR TITLE
Remove vehicle option that does not exist (vn_b_wheeled_m151_mg_01).

### DIFF
--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -304,10 +304,6 @@ class vehicles {
 		tags[] = {"m151a1","transport", "car"};
 	};
 
-	class vn_b_wheeled_m151_mg_01 {
-		tags[] = {"m151a1","armed","firesupport","car"};
-	};
-
 	class vn_b_wheeled_m151_mg_02 {
 		tags[] = {"m151a1","armed","firesupport","car"};
 	};


### PR DESCRIPTION
Fixes #169 

`vn_b_wheeled_m151_mg_01` doesn't exist as a vehicle class in the CDLC -- https://wiki.sogpf.com/index.php/CfgVehicles_WEST