### PR TITLE
Vehspawners: Use category submenu icon path for vehicle options.

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/client/fn_veh_asset_finalise_spawn_point_setup_on_client.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/client/fn_veh_asset_finalise_spawn_point_setup_on_client.sqf
@@ -56,7 +56,8 @@ private _vehicleCategories = _spawnPoint get "settings" get "categories";
         private _vehicle = _x;
         createHashMapFromArray [
             ["text", getText (configFile >> "CfgVehicles" >> (_vehicle get "classname") >> "displayName")],
-            ["iconPath", _vehicle get "icon"],
+            // vehicles don't have icon data, so make do with the category icon instead
+            ["iconPath", _category get "icon"],
             ["functionArguments", [_spawnPoint get "id", _vehicle get "classname"]],
             ["function", "vn_mf_fnc_veh_asset_request_vehicle_change_client"]
         ]


### PR DESCRIPTION
Previously, vehicle spawn menus did not show any icons for vehicles (no data in the configs for the icon paths).

This changes it so vehicle menu options will use their category's icon.

### categories
![20241123153707_1](https://github.com/user-attachments/assets/dee9973e-8462-4523-934f-2d3fa4ad3316)

### before
![20241123153714_1](https://github.com/user-attachments/assets/34b7db73-7b59-4f44-bcc7-31880065820a)

### after
![20241123153507_1](https://github.com/user-attachments/assets/173a8f26-1f86-4872-be92-0b723a3133fc)

