### PR TITLE
Add missing string table entry for RVN Civil Action Unit Citation.

### DIFF
--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -272,6 +272,9 @@
       <Key ID="STR_vn_mf_rvn_wound_medal">
         <Original>RVN Wound Medal</Original>
       </Key>
+      <Key ID="STR_vn_mf_rvn_civil_action_unit_citation">
+        <Original>RVN Civil Action Unit Citation</Original>
+      </Key>
       <Key ID="STR_vn_mf_distinguished_service_cross">
         <Original>Distinguished Service Cross</Original>
       </Key>


### PR DESCRIPTION
Defined here and used in the player info tab of the task roster

https://github.com/Savage-Game-Design/Mike-Force/blob/72e4c12ce8841d5fe6db997d1b99b003a22aa8e7/mission/config/subconfigs/awards_config.hpp#L331-L340