### PR TITLE
Server Parameter Options Rework

### DIFF
--- a/mission/config/params.hpp
+++ b/mission/config/params.hpp
@@ -1,62 +1,150 @@
-class wipe_save
+// @dijksterhuis: PR TODO: Add new Stringtable entries.
+// @dijksterhuis: PR TODO: Delete old description/subheading Stringtable entries.
+// @dijksterhuis: PR TODO: vn_artillery config options from here instead of config file?
+// @dijksterhuis: PR TODO: the bra mission.sqm needs the presence condition for advanced revive module added.
+// @dijksterhuis: PR TODO: sites -- configure the max random distance from site pos for markers?
+
+/* ================================ BOILERPLATE ================================*/
+
+#define TOGGLE_OPTION_DISABLED_DEFAULT(class_name, string_title) \
+    class class_name \
+    { \
+        title = string_title; \
+        values[] = {0, 1}; \
+        texts[] = {"Disabled (Default)", "Enabled"}; \
+        default = 0; \
+    };
+
+#define TOGGLE_OPTION_ENABLED_DEFAULT(class_name, string_title) \
+    class class_name \
+    { \
+        title = string_title; \
+        values[] = {0, 1}; \
+        texts[] = {"Disabled", "Enabled (Default)"}; \
+        default = 1; \
+    };
+
+
+#define HEADER_CLASS(class_name, string_title) \
+    class class_name \
+    { \
+        title = string_title; \
+        values[] = {""}; \
+        texts[] = {""}; \
+        default = ""; \
+    };
+
+
+/* ================================ MISC ================================*/
+
+HEADER_CLASS(misc_header, "$STR_vn_mf_param_misc_header")
+
+TOGGLE_OPTION_DISABLED_DEFAULT(wipe_save, "$STR_vn_mf_param_wipe_save")
+TOGGLE_OPTION_DISABLED_DEFAULT(enable_ranks, "$STR_vn_mf_param_enable_ranks")
+TOGGLE_OPTION_ENABLED_DEFAULT(allow_map_markers, "$STR_vn_mf_param_allow_map_markers")
+
+class respawn_delay
 {
-    title = $STR_vn_mf_param_wipe_save;
-    values[] = {0, 1};
-    texts[] = {"False", "True"};
-    default = 0;
+    title = $STR_vn_mf_param_respawn_delay;
+    values[] = {5, 10, 20, 30};
+    texts[] = {"5 seconds", "10 seconds", "20 seconds (Default)", "30 seconds"};
+    default = 20;
 };
 
-class wipe_save_desc
+TOGGLE_OPTION_DISABLED_DEFAULT(
+    toggle_global_tutorials,
+    "TOGGLE TUTORIAL HINTS: Toggle tutorial hints for all players; overrides player gamemode option for tutorial hints"
+)
+
+/* ================================ ZONES ================================*/
+HEADER_CLASS(zones_header, "========================================== Zones ==========================================")
+
+class zones_concurrent_active_limit
 {
-    title = $STR_vn_mf_param_wipe_save_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = "ACTIVE ZONES LIMIT: Limit the number of active zones";
+    values[] = {1, 2, 3, 4, -1};
+    texts[] = {"One Zone", "Two Zones", "Three Zones", "Four Zones", "No Limit"};
+    default = -1;
 };
 
-class Spacer0
+class zones_marker_alpha_percent
 {
-    title = "";
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = "ZONE MARKER ALPHA: Change the zone map marker alpha value";
+    values[] = {0, 10, 20, 30, 40, 50, 60, 70};
+    texts[] = {"0% (Disabled)", "10%", "20%", "30%", "40%", "50% (Default)", "60%", "70%"};
+    default = 50;
 };
 
-class enable_ranks
+/* ================================ SITES ================================*/
+HEADER_CLASS(sites_header, "========================================== Sites ==========================================")
+
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    sites_passive_discovery_toggle,
+    "TOGGLE SITE PASSIVE DISCOVERY: Enable/Disable displaying site map markers when players are nearby"
+)
+
+class sites_partial_discovery_radius_meters
 {
-    title = $STR_vn_mf_param_enable_ranks;
-    values[] = {0, 1};
-    texts[] = {"False", "True"};
-    default = 0;
+    title = "PARTIAL DISCOVERY MARKER RADIUS: Radius from player where partially discovered site map markers display (red circles)";
+    values[] = {100, 200, 300, 400, 500};
+    texts[] = {"100M", "200M", "300M (Default)", "400M", "500M"};
+    default = 300;
 };
 
-class enable_ranks_desc
+class sites_partial_discovery_marker_alpha_percent
 {
-    title = $STR_vn_mf_param_enable_ranks_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = "PARTIAL DISCOVERY MARKER ALPHA: Change the map marker alpha value for partially discovered sites (red circles)";
+    values[] = {0, 10, 20, 30, 40, 50, 60, 70};
+    texts[] = {"0% (Disabled)", "10%", "20%", "30% (Default)", "40%", "50%", "60%", "70%"};
+    default = 30;
 };
 
-class Spacer21 : Spacer0 {};
-
-class allow_map_markers
+class sites_discovery_radius_meters
 {
-    title = $STR_vn_mf_param_allow_map_markers;
-    values[] = {0, 1};
-    texts[] = {"False", "True"};
+    title = "FULL DISCOVERY MARKER RADIUS: Radius from player where fully discovered site map markers display (objective markers)";
+    values[] = {25, 50, 75, 100, 150, 200};
+    texts[] = {"25M", "50M (Default)", "75M", "100M", "150M", "200M"};
+    default = 50;
+};
+
+class sites_discovery_marker_alpha_percent
+{
+    title = "FULL DISCOVERY MARKER ALPHA: Change the map marker alpha value for fully discovered sites (objective markers)";
+    values[] = {0, 10, 20, 30, 40, 50, 60, 70};
+    texts[] = {"0% (Disabled)", "10%", "20%", "30%", "40%", "50% (Default)", "60%", "70%"};
+    default = 50;
+};
+
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    sites_discovery_aa_marker_toggle,
+    "TOGGLE AA AOE FULL DISCOVERY MARKER: Toggle the hashed 'area of effect' marker for fully discovered AA sites"
+)
+
+class sites_scout_action_cooldown_seconds
+{
+    title = "SCOUTING COOLDOWN: Time players must wait until they can use the scout action again";
+    values[] = {15, 30, 45, 60, 90, 120, 180, 300, 600};
+    texts[] = {"15 Seconds", "30 Seconds (Default)", "45 Seconds", "60 Seconds", "90 Seconds", "2 Minutes", "3 Minutes", "5 Minutes", "10 Minutes"};
+    default = 30;
+};
+
+/* ================================ STAMINA ================================*/
+
+HEADER_CLASS(stamina_header, "$STR_vn_mf_param_stamina_header")
+
+TOGGLE_OPTION_DISABLED_DEFAULT(enable_stamina, "$STR_vn_mf_param_enable_stamina")
+
+class set_stamina
+{
+    title = $STR_vn_mf_param_set_stamina;
+    values[] = {0, 1, 2, 3};
+    texts[] = {"Normal", "Default", "FastDrain", "Exhausted"};
     default = 1;
 };
 
-class allow_map_markers_desc
-{
-    title = $STR_vn_mf_param_allow_map_markers_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
+/* ================================ AI UNITS ================================*/
 
-class Spacer1 : Spacer0 {};
+HEADER_CLASS(ai_header, "$STR_vn_mf_param_ai_header")
 
 class hard_ai_limit
 {
@@ -66,16 +154,6 @@ class hard_ai_limit
     default = 80;
 };
 
-class hard_ai_limit_desc
-{
-    title = $STR_vn_mf_param_hard_ai_limit_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class Spacer1_0 : Spacer0 {};
-
 class ai_scaling
 {
     title = $STR_vn_mf_param_ai_scaling;
@@ -84,120 +162,230 @@ class ai_scaling
     default = 100;
 };
 
-class ai_scaling_desc
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    ai_harass_enabled,
+    "TOGGLE AI HARASS: Enable AI harassment units to track/hunt players on specific teams"
+)
+
+class ai_harass_minimum_delay
 {
-    title = $STR_vn_mf_param_ai_scaling_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = "AI HARASS MINIMUM SPAWN DELAY: Minimum timne between spawning new harassment units";
+    values[] = {60, 120, 180, 240, 300, 360};
+    texts[] = {"1 Minute", "2 Minutes", "3 Minutes", "4 Minutes (Default)", "5 Minutes", "6 Minutes"};
+    default = 240;
 };
 
-class Spacer1_1 : Spacer0 {};
+TOGGLE_OPTION_DISABLED_DEFAULT(
+    ai_harass_inside_zones,
+    "AI HARASSMENT IN ZONES: Whether harassment units will spawn for players inside active zones or not"
+)
 
-// gamemode specific start
-class buildables_require_vehicles
-{
-    title = $STR_vn_mf_buildables_require_vehicles;
-    values[] = {0, 1};
-    texts[] = {"False", "True"};
-    default = 0;
-};
 
-class buildables_require_vehicles_desc
-{
-    title = $STR_vn_mf_buildables_require_vehicles_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
+/* ================================ BUILDING SYSTEMS ================================*/
 
-class Spacer2 : Spacer1 {};
+HEADER_CLASS(building_header, "$STR_vn_mf_param_building_header")
 
-class dawn_length
-{
-    title = $STR_vn_mf_dawn_length;
-    values[] = {600, 1200, 1800, 2400, 3600, 5400, 7200, 9000, 10800};
-    texts[] = {"10 minutes", "20 minutes", "30 minutes", "40 minutes", "1 hour", "1.5 hours", "2 hours", "2.5 hours", "3 hours"};
-    default = 1200;
-};
-
-class Spacer3 : Spacer1 {};
-
-class day_length
-{
-    title = $STR_vn_mf_day_length;
-    values[] = {3600, 5400, 7200, 9000, 10800, 21600, 43200, 86400, 172800};
-    texts[] = {"1 hour", "1.5 hours", "2 hours", "2.5 hours", "3 hours", "6 hours", "12 hours", "24 hours", "48 hours"};
-    default = 7200;
-};
-
-class Spacer4 : Spacer1 {};
-
-class dusk_length
-{
-    title = $STR_vn_mf_dusk_length;
-    values[] = {600, 1200, 1800, 2400, 3600, 5400, 7200, 9000, 10800};
-    texts[] = {"10 minutes", "20 minutes", "30 minutes", "40 minutes", "1 hour", "1.5 hours", "2 hours", "2.5 hours", "3 hours"};
-    default = 1200;
-};
-
-class Spacer5 : Spacer1 {};
-
-class night_length
-{
-    title = $STR_vn_mf_night_length;
-    values[] = {600, 1200, 1800, 2400, 3600, 5400, 7200, 9000, 10800, 21600, 43200, 86400, 172800};
-    texts[] = {"10 minutes", "20 minutes", "30 minutes", "40 minutes", "1 hour", "1.5 hours", "2 hours", "2.5 hours", "3 hours", "6 hours", "12 hours", "24 hours", "48 hours"};
-    default = 1200;
-};
-
-class Spacer7 : Spacer1 {};
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    toggle_building_systems,
+    "TOGGLE BUILDING SYSTEM: Enable/disable the Mike Force build system for all players."
+)
+TOGGLE_OPTION_DISABLED_DEFAULT(
+    buildables_require_vehicles,
+    "$STR_vn_mf_buildables_require_vehicles"
+)
 
 class building_sandbag_value
 {
     title = $STR_vn_mf_building_sandbag_value;
-    values[] = {10};
-    texts[] = {"Default (10)"};
+    values[] = {1, 5, 10, 20, 30, 40, 50};
+    texts[] = {"1", "5", "10 (Default)", "20", "30", "40", "50"};
     default = 10;
 };
 
-class building_sandbag_value_desc
+/* ================================ VEHICLE SYSTEMS ================================*/
+
+HEADER_CLASS(veh_asset_header, "========================================== Vehicle Asset Management ==========================================")
+
+class veh_asset_abandoned_timer_seconds
 {
-    title = $STR_vn_mf_building_sandbag_value_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = "IDLE VEHICLE TIMER: Length of time until vehicles are marked as abandoned (idle) on map"
+    values[] = {120, 180, 240, 300, 360, 420, 480, 540, 600};
+    texts[] = {"2 Minutes", "3 Minutes", "4 Minutes", "5 Minutes (Default)", "6 Minutes", "7 Minutes", "8 Minutes", "9 Minutes", "10 Minutes"};
+    default = 300;
 };
 
-class Spacer8 : Spacer1 {};
-
-class advanced_revive
+class veh_asset_abandoned_min_distance
 {
-    title = $STR_vn_mf_advanced_revive;
-    values[] = {1, 0};
-    texts[] = {"True (Default)", "False"};
+    title = "IDLE VEHICLE DISTANCE: Distance from the vehicle spawn point for vehicles to be marked as abandoned (idle) on map"
+    values[] = {20, 60, 100, 140, 180};
+    texts[] = {"20 Meters (Default)", "60 Meters", "100 Meters", "140 Meters", "180 Meters"};
+    default = 20;
+};
+
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    veh_asset_lock_idle_vehicles,
+    "IDLE VEHICLE LOCKING TOGGLE: Whether abandoned (idle) vehicles should be locked (simulation disabled)"
+)
+
+class veh_asset_relock_time_seconds
+{
+    title = "IDLE VEHICLE LOCK TIME: How long to wait before locking a vehicle once it is marked as abandoned (idle)"
+    values[] = {10, 30, 60, 90, 120};
+    texts[] = {"10", "30 (Default)", "60", "90", "120"};
+    default = 30;
+};
+
+class veh_asset_marker_update_delay_seconds
+{
+    title = "MARKER UPDATE TIMER: Length of time between updating position of a vehicle's map marker"
+    values[] = {10, 30, 60, 90, 120};
+    texts[] = {"10 (Default)", "30", "60", "90", "120"};
+    default = 10;
+};
+
+
+/* ================================ DAY / NIGHT TIME LENGTH ================================*/
+
+#define DAYNIGHT_TIME_CLASS(X, Y, Z) \
+    class X \
+    { \
+        title = Y; \
+        values[] = {600, 1200, 1800, 2400, 3600, 5400, 7200, 9000, 10800, 21600, 43200, 86400, 172800}; \
+        texts[] = {"10 minutes", "20 minutes", "30 minutes", "40 minutes", "1 hour", "1.5 hours", "2 hours", "2.5 hours", "3 hours", "6 hours", "12 hours", "24 hours", "48 hours"}; \
+        default = Z; \
+    };
+
+
+HEADER_CLASS(daynight_length_header, "$STR_vn_mf_param_daynight_length_header")
+
+DAYNIGHT_TIME_CLASS(dawn_length, "$STR_vn_mf_dawn_length", 1200)
+DAYNIGHT_TIME_CLASS(day_length, "$STR_vn_mf_day_length", 7200)
+DAYNIGHT_TIME_CLASS(dusk_length, "$STR_vn_mf_dusk_length", 1200)
+DAYNIGHT_TIME_CLASS(night_length, "$STR_vn_mf_night_length", 1200)
+
+/* ================================ MAX PLAYERS PER TEAM ================================*/
+
+#define MAXPLAYERS_CLASS(X, Y, Z) \
+    class X \
+    { \
+        title = Y; \
+        values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 99}; \
+        texts[] = {"0 players", "1 player", "2 players", "3 players", "4 players", "5 players", "6 players", "7 players", "8 players", "9 players", "10 players", "15 players", "20 players", "25 players", "30 players", "35 players", "40 players", "45 players", "50 players", "99 players"}; \
+        default = Z; \
+    };
+
+HEADER_CLASS(teams_header, "$STR_vn_mf_param_teams_header")
+
+MAXPLAYERS_CLASS(max_players_acav, "$STR_vn_mf_max_players_acav", 99)
+MAXPLAYERS_CLASS(max_players_greenhornets, "$STR_vn_mf_max_players_greenhornets", 99)
+MAXPLAYERS_CLASS(max_players_mikeforce, "$STR_vn_mf_max_players_mikeforce", 99)
+MAXPLAYERS_CLASS(max_players_spiketeam, "$STR_vn_mf_max_players_spiketeam", 6)
+
+/* ================================ VN SUPPORT MODULE ================================*/
+
+HEADER_CLASS(vnsupport_header, "$STR_vn_mf_param_vnsupport_header")
+
+class enable_air_support
+{
+    title = $STR_vn_mf_enable_air_support;
+    values[] = {0, 1, 2};
+    texts[] = {"Disabled", "Enabled (Default)", "Enabled: Unique Supports Only"};
     default = 1;
 };
 
-class advanced_revive_desc
+TOGGLE_OPTION_DISABLED_DEFAULT(enable_arty_support, "$STR_vn_mf_enable_arty_support")
+
+/* ================================ MEDICAL SYSTEM ================================*/
+
+HEADER_CLASS(medical_header, "$STR_vn_mf_param_medical_header")
+
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    advanced_revive,
+    "TOGGLE ADVANCED REVIVE: Toggles SOG Prairie Fire Medical System; subsequent medical settings are ignored when disabled"
+)
+TOGGLE_OPTION_DISABLED_DEFAULT(revive_headshot_kill, "$STR_vn_mf_param_headshot_kill")
+TOGGLE_OPTION_ENABLED_DEFAULT(always_allow_withstand, "$STR_vn_mf_always_allow_withstand")
+
+class revive_bleedout_time
 {
-    title = $STR_vn_mf_advanced_revive_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = $STR_vn_mf_param_bleedout_time;
+    values[] = {100, 200, 300, 400, 500};
+    texts[] = {"100", "200", "300 (Default)", "400", "500"};
+    default = 300;
 };
 
-class Spacer9 : Spacer1 {};
-
-class snake_header
+class revive_withstand_percentage
 {
-    title = $STR_vn_mf_param_snake_header;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
+    title = $STR_vn_mf_param_withstand_percentage;
+    values[] = {30, 50, 70, 80, 100};
+    texts[] = {"70%", "50%", "30%", "20% (Default)", "0%"};
+    default = 80;
 };
 
-class Spacer11 : Spacer1 {};
+class revive_respawn_action_time
+{
+    title = "RESPAWN PERCENTAGE: Percentage of bleedout time that must pass before respawning is an option";
+    values[] = {25, 45, 65, 75, 95};
+    texts[] = {"75%", "55%", "35%", "25% (Default)", "5%"};
+    default = 75;
+};
+
+class revive_revive_delay
+{
+    title = "REVIVE DELAY: How long players must wait until they can revive a patient";
+    values[] = {0, 5, 10, 15, 20, 30, 45, 60};
+    texts[] = {"No Delay", "5 Seconds (Default)", "10 Seconds", "15 Seconds", "20 Seconds", "30 Seconds", "45 Seconds", "60 Seconds"};
+    default = 5;
+};
+
+TOGGLE_OPTION_ENABLED_DEFAULT(
+    revive_bleedout_affects_actions,
+    "TOGGLE BLEEDOUT AFFECTS ACTIONS: If the time spent bleeding out decreases the chances to complete actions."
+)
+
+// @dijksterhuis: PR TODO: Add other chance actions (again)
+
+class revive_move_chance
+{
+    title = "ROLL OVER MOVE CHANCE: Base chance of rolling over when pressing movement keys (multiplied by current bleedout time)";
+    values[] = {0, 25, 50, 75, 100};
+    texts[] = {"0%", "25%", "50%", "75% (Default)", "100%"};
+    default = 75;
+};
+
+TOGGLE_OPTION_DISABLED_DEFAULT(revive_revive_requirement, "$STR_vn_mf_param_revive_requirement")
+
+class revive_bandage_item
+{
+    values[] = {0, 1, 2};
+    title = "BANDAGE ITEMS: Items that can be used to stabilize patients";
+    texts[] = {"Nothing", "Medikits", "Medikits + First Aid Kits (Default)"};
+    default = 2;
+};
+
+TOGGLE_OPTION_ENABLED_DEFAULT(revive_remove_bandage_item, "$STR_vn_mf_param_remove_bandage_item")
+
+class revive_revive_item
+{
+    values[] = {0, 1, 2};
+    title = "REVIVE ITEMS: Items that can be used to resucitate patients";
+    texts[] = {"Nothing", "Medikits", "Medikits + First Aid Kits (Default)"};
+    default = 2;
+};
+
+TOGGLE_OPTION_DISABLED_DEFAULT(revive_remove_revive_item, "$STR_vn_mf_param_remove_revive_item")
+
+class revive_icon_distance
+{
+    title = "INCAPACITATED ICON DISTANCE";
+    values[] = {0, 25, 50, 75, 100, 125, 150, 175, 200};
+    texts[] = {"0 Meters", "25 Meters", "50 Meters (Default)", "75 Meters", "100 Meters", "125 Meters", "150 Meters", "175 Meters", "200 Meters"};
+    default = 50;
+};
+
+/* ================================ SNAKE BITES ================================*/
+
+HEADER_CLASS(snake_header, "$STR_vn_mf_param_snake_header")
 
 class snake_bite_chance
 {
@@ -205,14 +393,6 @@ class snake_bite_chance
     values[] = {0, 15, 25, 35, 50, 65, 75};
     texts[] = {"0% (Off)", "15%", "25%", "35%", "50% (Default)", "65%", "75%"};
     default = 50;
-};
-
-class snake_bite_chance_desc
-{
-    title = $STR_vn_mf_param_snake_bite_chance_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
 };
 
 class snake_bite_distance
@@ -223,28 +403,12 @@ class snake_bite_distance
     default = 100;
 };
 
-class snake_bite_distance_desc
-{
-    title = $STR_vn_mf_param_snake_bite_distance_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
 class snake_bite_frequency
 {
     title = $STR_vn_mf_param_snake_bite_frequency;
     values[] = {150, 300, 450, 600};
     texts[] = {"2.5 minutes", "5 minutes (Default)", "7.5 minutes", "10 minutes"};
     default = 300;
-};
-
-class snake_bite_frequency_desc
-{
-    title = $STR_vn_mf_param_snake_bite_frequency_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
 };
 
 class snake_bite_extra_time
@@ -255,212 +419,9 @@ class snake_bite_extra_time
     default = 300;
 };
 
-class snake_bite_extra_time_desc
-{
-    title = $STR_vn_mf_param_snake_bite_extra_time_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
+/* ================================ HUNGER/THIRST ================================*/
 
-class Spacer12 : Spacer1 {};
-
-class teams_header
-{
-    title = $STR_vn_mf_param_teams_header;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class Spacer13 : Spacer1 {};
-
-class max_players_acav
-{
-    title = $STR_vn_mf_max_players_acav;
-    values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 99};
-    texts[] = {"0 players", "1 player", "2 players", "3 players", "4 players", "5 players", "6 players", "7 players", "8 players", "9 players", "10 players", "15 players", "20 players", "25 players", "30 players", "35 players", "40 players", "45 players", "50 players", "Default (99 players)"};
-    default = 99;
-};
-
-class max_players_greenhornets
-{
-    title = $STR_vn_mf_max_players_greenhornets;
-    values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 99};
-    texts[] = {"0 players", "1 player", "2 players", "3 players", "4 players", "5 players", "6 players", "7 players", "8 players", "9 players", "10 players", "15 players", "20 players", "25 players", "30 players", "35 players", "40 players", "45 players", "50 players", "Default (99 players)"};
-    default = 99;
-};
-
-class max_players_mikeforce
-{
-    title = $STR_vn_mf_max_players_mikeforce;
-    values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 99};
-    texts[] = {"0 players", "1 player", "2 players", "3 players", "4 players", "5 players", "6 players", "7 players", "8 players", "9 players", "10 players", "15 players", "20 players", "25 players", "30 players", "35 players", "40 players", "45 players", "50 players", "Default (99 players)"};
-    default = 99;
-};
-
-class max_players_spiketeam
-{
-    title = $STR_vn_mf_max_players_spiketeam;
-    values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 99};
-    texts[] = {"0 players", "1 player", "2 players", "3 players", "4 players", "5 players", "6 players", "7 players", "8 players", "9 players", "10 players", "15 players", "20 players", "25 players", "30 players", "35 players", "40 players", "45 players", "50 players", "Default (99 players)"};
-    default = 6;
-};
-
-
-class Spacer14 : Spacer1 {};
-
-class enable_air_support
-{
-    title = $STR_vn_mf_enable_air_support;
-    values[] = {0, 1, 2};
-    texts[] = {"Off", "On (Default)", "Unique Supports Only"};
-    default = 1;
-};
-
-class enable_air_support_desc
-{
-    title = $STR_vn_mf_enable_air_support_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-  
-  class enable_arty_support
-{
-    title = $STR_vn_mf_enable_arty_support;
-    values[] = {0, 1};
-    texts[] = {"Off", "On (Default)"};
-    default = 1;
-};
-
-class Spacer15 : Spacer1 {};
-
-class medical_header
-{
-    title = $STR_vn_mf_param_medical_header;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class Spacer16 : Spacer1 {};
-
-class headshot_kill
-{
-    title = $STR_vn_mf_param_headshot_kill;
-    values[] = {0, 1};
-    texts[] = {"Off (Default)", "On"};
-    default = 0;
-};
-
-class headshot_kill_desc
-{
-    title = $STR_vn_mf_param_headshot_kill_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-class bleedout_time
-{
-    title = $STR_vn_mf_param_bleedout_time;
-    values[] = {100, 200, 300, 400, 500};
-    texts[] = {"100", "200", "300 (Default)", "400", "500"};
-    default = 300;
-};
-
-class bleedout_time_desc
-{
-    title = $STR_vn_mf_param_bleedout_time_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class always_allow_withstand
-{
-    title = $STR_vn_mf_always_allow_withstand;
-    values[] = {0, 1};
-    texts[] = {"Off", "On (Default)"};
-    default = 1;
-};
-
-
-class always_allow_withstand_desc
-{
-    title = $STR_vn_mf_always_allow_withstand_desc;
-
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class withstand_percentage
-{
-    title = $STR_vn_mf_param_withstand_percentage;
-    values[] = {50, 70, 80, 100};
-    texts[] = {"50%", "30%", "20% (Default)", "0%"};
-    default = 80;
-};
-
-class withstand_percentage_desc
-{
-    title = $STR_vn_mf_param_withstand_percentage_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class remove_bandage_item
-{
-    title = $STR_vn_mf_param_remove_bandage_item;
-    values[] = {0, 1};
-    texts[] = {"Off", "On (Default)"};
-    default = 1;
-};
-
-
-class remove_bandage_item_desc
-{
-    title = $STR_vn_mf_param_remove_bandage_item_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class remove_revive_item
-{
-    title = $STR_vn_mf_param_remove_revive_item;
-    values[] = {0, 1};
-    texts[] = {"Off (Default)", "On"};
-    default = 0;
-};
-
-class remove_revive_item_desc
-{
-    title = $STR_vn_mf_param_remove_revive_item_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class revive_requirement
-{
-    title = $STR_vn_mf_param_revive_requirement;
-    values[] = {0, 1};
-    texts[] = {"Off (Default)", "On"};
-    default = 0;
-};
-
-class respawn_delay
-{
-    title = $STR_vn_mf_param_respawn_delay;
-    values[] = {5, 10, 20, 30};
-    texts[] = {"5 seconds", "10 seconds", "20 seconds (Default)", "30 seconds"};
-    default = 20;
-};
-  
-class Spacer17 : Spacer1 {};
+HEADER_CLASS(consumables_header, "$STR_vn_mf_param_hunger_thirst_header")
 
 class hunger_loss_rate
 {
@@ -468,14 +429,6 @@ class hunger_loss_rate
     values[] = {1, 5, 10, 25, 50, 100};
     texts[] = {"0.01%", "0.05% (Default)", "0.1%", "0.25%", "0.5%", "1%"};
     default = 5;
-};
-
-class hunger_loss_rate_desc
-{
-    title = $STR_vn_mf_param_hunger_loss_rate_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
 };
 
 class thirst_loss_rate
@@ -486,43 +439,9 @@ class thirst_loss_rate
     default = 10;
 };
 
-class thirst_loss_rate_desc
-{
-    title = $STR_vn_mf_param_thirst_loss_rate_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
+/* ================================ CLEAN UP SYSTEMS ================================*/
 
-class Spacer18: Spacer1 {};
-
-class enable_stamina
-{
-    title = $STR_vn_mf_param_enable_stamina;
-    values[] = {1, 0};
-    texts[] = {"True", "False"};
-    default = 1;
-};
-
-class set_stamina
-{
-    title = $STR_vn_mf_param_set_stamina;
-    values[] = {0, 1, 2, 3};
-    texts[] = {"Normal", "Default", "FastDrain", "Exhausted"};
-    default = 1;
-};
-
-class Spacer19: Spacer1 {};
-
-class cleanup_header
-{
-    title = $STR_vn_mf_param_cleanup_header;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
-
-class Spacer20: Spacer1 {};
+HEADER_CLASS(cleanup_header, "$STR_vn_mf_param_cleanup_header")
 
 class cleanup_min_player_distance
 {
@@ -530,14 +449,6 @@ class cleanup_min_player_distance
     values[] = {10, 50, 100, 200, 300, 400, 500, 1000};
     texts[] = {"10m", "50m", "100m", "200m", "300m", "400m", "500m", "1000m"};
     default = 400;
-};
-
-class cleanup_min_player_distance_desc
-{
-    title = $STR_vn_mf_param_cleanup_min_player_distance_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
 };
 
 class cleanup_max_bodies
@@ -548,21 +459,8 @@ class cleanup_max_bodies
     default = 50;
 };
 
-class cleanup_placed_gear
-{
-    title = $STR_vn_mf_param_cleanup_placed_gear;
-    values[] = {1, 0};
-    texts[] = {"Yes", "No"};
-    default = 1;
-};
-
-class cleanup_placed_gear_desc
-{
-    title = $STR_vn_mf_param_cleanup_placed_gear_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
-};
+TOGGLE_OPTION_ENABLED_DEFAULT(cleanup_placed_gear, "$STR_vn_mf_param_cleanup_placed_gear")
+TOGGLE_OPTION_ENABLED_DEFAULT(cleanup_dropped_gear, "$STR_vn_mf_param_cleanup_dropped_gear")
 
 class cleanup_placed_gear_lifetime
 {
@@ -570,22 +468,6 @@ class cleanup_placed_gear_lifetime
     values[] = {60, 120, 180, 300, 600, 1800, 3600};
     texts[] = {"1 minute", "2 minutes", "3 minutes", "5 minutes", "10 minutes", "30 minutes", "1 hour"};
     default = 300;
-};
-
-class cleanup_dropped_gear
-{
-    title = $STR_vn_mf_param_cleanup_dropped_gear;
-    values[] = {1, 0};
-    texts[] = {"Yes", "No"};
-    default = 1;
-};
-
-class cleanup_dropped_gear_desc
-{
-    title = $STR_vn_mf_param_cleanup_dropped_gear_desc;
-    values[] = {""};
-    texts[] = {""};
-    default = "";
 };
 
 class cleanup_dropped_gear_lifetime

--- a/mission/config/params.hpp
+++ b/mission/config/params.hpp
@@ -3,7 +3,17 @@
 // @dijksterhuis: PR TODO: vn_artillery config options from here instead of config file?
 // @dijksterhuis: PR TODO: the bra mission.sqm needs the presence condition for advanced revive module added.
 // @dijksterhuis: PR TODO: sites -- configure the max random distance from site pos for markers?
+// @dijksterhuis: PR TODO: helper function to load booleans variable from 0/1 parameter values (see below)
+/*
+// ["sites_discovery_something_bool", false] call _fnc_load_from_params;
 
+params [
+    ["_param_key", "", ""],
+    ["_default_value", false, true]
+];
+
+[false, true] select ([param_key, [0, 1] select _default_value] call BIS_fnc_getParamValue);
+*/
 /* ================================ BOILERPLATE ================================*/
 
 #define TOGGLE_OPTION_DISABLED_DEFAULT(class_name, string_title) \

--- a/mission/functions/core/fn_marker_init.sqf
+++ b/mission/functions/core/fn_marker_init.sqf
@@ -22,6 +22,14 @@ vn_mf_markers_supply_officer_initial = [];
 vn_mf_markers_wreck_recovery = [];
 vn_mf_markers_no_harass = [];
 
+vn_mf_s_markers_zone_alpha_percent = (
+	(["zones_marker_alpha_percent", 50] call BIS_fnc_getParamValue) / 100
+);
+
+vn_mf_s_markers_zone_allow_harass = (
+	[false, true] select (["ai_harass_inside_zones", 0] call BIS_fnc_getParamValue)
+);
+
 {
 	if (_x find "mf_respawn_" isEqualTo 0) then {
 		vn_mf_markers_base_respawns pushBack _x;
@@ -51,11 +59,16 @@ vn_mf_markers_no_harass = [];
 		//Hide location marker used for mission mockup
 		_locationMarker setMarkerAlpha 0;
 
-		private _noHarassMarker = createMarker [format ["no_harass_%1", _x], getMarkerPos _x];
-		_noHarassMarker setMarkerShape "ELLIPSE";
-		_noHarassMarker setMarkerSize [200, 200];
-		_noHarassMarker setMarkerAlpha 0;
-		vn_mf_markers_no_harass pushBack _noHarassMarker;
+		_x setMarkerAlpha vn_mf_s_markers_zone_alpha_percent;
+
+		if (!vn_mf_s_markers_zone_allow_harass) then {
+			private _noHarassMarker = createMarker [format ["no_harass_%1", _x], getMarkerPos _x];
+			_noHarassMarker setMarkerShape "ELLIPSE";
+			_noHarassMarker setMarkerSize [200, 200];
+			_noHarassMarker setMarkerAlpha 0;
+			vn_mf_markers_no_harass pushBack _noHarassMarker;
+		};
+
 	};
 	if (_x find "wreck_recovery" isEqualTo 0) then {
 		vn_mf_markers_wreck_recovery pushBack _x;

--- a/mission/functions/core/init/fn_adv_revive_params.sqf
+++ b/mission/functions/core/init/fn_adv_revive_params.sqf
@@ -62,17 +62,3 @@ missionNamespace setVariable ["vn_revive_bandage_item", _bandage_item_arr, true]
 
 private _revive_item_arr = _medical_items_arr select (["revive_revive_item", 2] call BIS_fnc_getParamValue);
 missionNamespace setVariable ["vn_revive_revive_item", _revive_item_arr, true];
-
-// private _headshot_kill = ["revive_headshot_kill", 0] call BIS_fnc_getParamValue;
-// private _bleedout_time = ["revive_bleedout_time", 300] call BIS_fnc_getParamValue;
-// private _withstand_percentage = ["revive_withstand_percentage", 80] call BIS_fnc_getParamValue;
-// private _bandage_item_remove = ["revive_remove_bandage_item", 1] call BIS_fnc_getParamValue;
-// private _revive_item_remove = ["revive_remove_revive_item", 1] call BIS_fnc_getParamValue;
-// private _revive_requirement = ["revive_revive_requirement", 1] call BIS_fnc_getParamValue;
-
-// missionNamespace setVariable ["vn_revive_headshot_kill",[false,true] select _headshot_kill,true];
-// missionNamespace setVariable ["vn_revive_bleedout_time",_bleedout_time,true];
-// missionNamespace setVariable ["vn_revive_withstand_percentage",_withstand_percentage,true];
-// missionNamespace setVariable ["vn_revive_bandage_item_remove",[false,true] select _bandage_item_remove,true];
-// missionNamespace setVariable ["vn_revive_revive_item_remove",[false,true] select _revive_item_remove,true];
-// missionNamespace setVariable ["vn_revive_revive_requirement",[false,true] select _revive_requirement,true];

--- a/mission/functions/core/init/fn_adv_revive_params.sqf
+++ b/mission/functions/core/init/fn_adv_revive_params.sqf
@@ -13,16 +13,66 @@
     Example(s): none
 */
 
-private _headshot_kill = ["headshot_kill", 0] call BIS_fnc_getParamValue;
-private _bleedout_time = ["bleedout_time", 300] call BIS_fnc_getParamValue;
-private _withstand_percentage = ["withstand_percentage", 80] call BIS_fnc_getParamValue;
-private _bandage_item_remove = ["remove_bandage_item", 1] call BIS_fnc_getParamValue;
-private _revive_item_remove = ["remove_revive_item", 1] call BIS_fnc_getParamValue;
-private _revive_requirement = ["revive_requirement", 1] call BIS_fnc_getParamValue;
 
-missionNamespace setVariable ["vn_revive_headshot_kill",[false,true] select _headshot_kill,true];
-missionNamespace setVariable ["vn_revive_bleedout_time",_bleedout_time,true];
-missionNamespace setVariable ["vn_revive_withstand_percentage",_withstand_percentage,true];
-missionNamespace setVariable ["vn_revive_bandage_item_remove",[false,true] select _bandage_item_remove,true];
-missionNamespace setVariable ["vn_revive_revive_item_remove",[false,true] select _revive_item_remove,true];
-missionNamespace setVariable ["vn_revive_revive_requirement",[false,true] select _revive_requirement,true];
+// Toggles
+
+private _headshot_kill = [false, true] select (["revive_headshot_kill", 0] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_headshot_kill", _headshot_kill, true];
+
+private _bandage_item_remove = [false, true] select (["revive_remove_bandage_item", 1] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_bandage_item_remove", _bandage_item_remove, true];
+
+private _revive_item_remove = [false, true] select (["revive_remove_revive_item", 1] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_revive_item_remove", _revive_item_remove, true];
+
+private _revive_requirement = [false, true] select (["revive_revive_requirement", 1] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_revive_requirement", _revive_requirement, true];
+
+private _revive_bleedout_affects_actions = [false, true] select (["revive_bleedout_affects_actions", 1] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_bleedout_affects_actions", _revive_bleedout_affects_actions, true];
+
+// Real values / selections
+
+private _bleedout_time = ["revive_bleedout_time", 300] call BIS_fnc_getParamValue;
+missionNamespace setVariable ["vn_revive_bleedout_time", _bleedout_time, true];
+
+private _withstand_percentage = ["revive_withstand_percentage", 80] call BIS_fnc_getParamValue;
+missionNamespace setVariable ["vn_revive_withstand_percentage", _withstand_percentage, true];
+
+private _revive_revive_delay = ["revive_revive_delay", 5] call BIS_fnc_getParamValue;
+missionNamespace setVariable ["vn_revive_revive_delay", _revive_revive_delay, true];
+
+private _revive_move_chance = ["revive_move_chance", 75] call BIS_fnc_getParamValue;
+missionNamespace setVariable ["vn_revive_move_chance", _revive_move_chance, true];
+
+private _revive_respawn_action_time = ["revive_respawn_action_time", 75] call BIS_fnc_getParamValue;
+missionNamespace setVariable ["vn_revive_respawn_action_time", _revive_respawn_action_time, true];
+
+private _revive_icon_distance = ["revive_icon_distance", 50] call BIS_fnc_getParamValue;
+missionNamespace setVariable ["vn_revive_icon_distance", _revive_icon_distance, true];
+
+private _medical_items_arr = [
+    [],
+    ["Medikit","vn_b_item_medikit_01"],
+    ["FirstAidKit","vn_o_item_firstaidkit","vn_b_item_firstaidkit", "vn_b_item_medikit_01", "Medikit"]
+];
+
+private _bandage_item_arr = _medical_items_arr select (["revive_bandage_item", 2] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_bandage_item", _bandage_item_arr, true];
+
+private _revive_item_arr = _medical_items_arr select (["revive_revive_item", 2] call BIS_fnc_getParamValue);
+missionNamespace setVariable ["vn_revive_revive_item", _revive_item_arr, true];
+
+// private _headshot_kill = ["revive_headshot_kill", 0] call BIS_fnc_getParamValue;
+// private _bleedout_time = ["revive_bleedout_time", 300] call BIS_fnc_getParamValue;
+// private _withstand_percentage = ["revive_withstand_percentage", 80] call BIS_fnc_getParamValue;
+// private _bandage_item_remove = ["revive_remove_bandage_item", 1] call BIS_fnc_getParamValue;
+// private _revive_item_remove = ["revive_remove_revive_item", 1] call BIS_fnc_getParamValue;
+// private _revive_requirement = ["revive_revive_requirement", 1] call BIS_fnc_getParamValue;
+
+// missionNamespace setVariable ["vn_revive_headshot_kill",[false,true] select _headshot_kill,true];
+// missionNamespace setVariable ["vn_revive_bleedout_time",_bleedout_time,true];
+// missionNamespace setVariable ["vn_revive_withstand_percentage",_withstand_percentage,true];
+// missionNamespace setVariable ["vn_revive_bandage_item_remove",[false,true] select _bandage_item_remove,true];
+// missionNamespace setVariable ["vn_revive_revive_item_remove",[false,true] select _revive_item_remove,true];
+// missionNamespace setVariable ["vn_revive_revive_requirement",[false,true] select _revive_requirement,true];

--- a/mission/functions/systems/director/fn_director_open_connected_zones.sqf
+++ b/mission/functions/systems/director/fn_director_open_connected_zones.sqf
@@ -28,6 +28,13 @@ _potentialZonesToOpen = _potentialZonesToOpen arrayIntersect _potentialZonesToOp
 
 private _zonesToOpen = _potentialZonesToOpen - _capturedZones - _activeZones;
 
+private _concurrent_zones_limit = ["zones_concurrent_active_limit", -1] call BIS_fnc_getParamValue;
+
+if (_concurrent_zones_limit > 0) then {
+    _zonesToOpen resize _concurrent_zones_limit;
+    _zonesToOpen = _zonesToOpen select {_x isEqualType ""};
+};
+
 {
     [_x] call vn_mf_fnc_director_open_zone;
 } forEach _zonesToOpen;

--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -33,6 +33,9 @@ params ["_pos"];
 
 		//Create an AA warning marker.
 		private _markerPos = _spawnPos getPos [5 + random 10, random 360];
+
+		private _mainMarkers = [];
+
 		private _aaZoneMarker = createMarker [format ["AA_zone_%1", _siteId], _markerPos];
 		_aaZoneMarker setMarkerSize [1000, 1000];
 		_aaZoneMarker setMarkerShape "ELLIPSE";
@@ -41,6 +44,8 @@ params ["_pos"];
 		// hiden at spawn 0.3
 		_aaZoneMarker setMarkerAlpha 0;
 
+		// special mission parameterisation case, toggles display of AA 'area of effect' markers
+		if (vn_mf_s_sites_discovery_aa_marker_enabled) then {_mainMarkers pushBack _aaZoneMarker};
 
 		// create partially discovered marker
 		private _partialPos = _spawnPos getPos [10 + random 40, random 360];
@@ -56,6 +61,7 @@ params ["_pos"];
 		_aaMarker setMarkerText "AA";
 		// hiden at spawn 0.5
 		_aaMarker setMarkerAlpha 0;
+		_mainMarkers pushBack _aaMarker;
 
 		private _vehicles = _createdThings select 0;
 		private _groups = _createdThings select 1;
@@ -76,8 +82,7 @@ params ["_pos"];
 		_siteStore setVariable ["units", (_createdThings select 1)]; 
 		_siteStore setVariable ["groups", _groups];
 
-		
-		_siteStore setVariable ["markers", [_aaZoneMarker, _aaMarker], true];
+		_siteStore setVariable ["markers", _mainMarkers, true];
 		_siteStore setVariable ["partialMarkers", [_partialMarker], true];
 	},
 	//Teardown condition check code

--- a/mission/functions/systems/sites/fn_sites_discovery_job.sqf
+++ b/mission/functions/systems/sites/fn_sites_discovery_job.sqf
@@ -31,14 +31,14 @@ private _nearbyUndiscoveredSites =
   _siteRef setVariable ["partiallyDiscovered", true, true];
 
   if (_distance <= vn_mf_g_sites_discovery_radius) then {
-    _siteRef getVariable ["markers", []] apply {_x setMarkerAlpha 0.5};
+    _siteRef getVariable ["markers", []] apply {_x setMarkerAlpha vn_mf_c_sites_discovery_marker_alpha_percent};
     _siteRef getVariable ["partialMarkers", []] apply {_x setMarkerAlpha 0};
     _siteRef setVariable ["discovered", true, true];
     continue;
   };
 
   // Only set partial markers if we're not close enough to fully reveal
-  _siteRef getVariable ["partialMarkers", []] apply {_x setMarkerAlpha 0.3};
+  _siteRef getVariable ["partialMarkers", []] apply {_x setMarkerAlpha vn_mf_c_sites_partial_discovery_marker_alpha_percent};
 } forEach _nearbyUndiscoveredSites;
 
 true

--- a/mission/functions/systems/sites/fn_sites_init.sqf
+++ b/mission/functions/systems/sites/fn_sites_init.sqf
@@ -46,20 +46,3 @@ if !(_loadSuccessful) then
 };
 
 [] call vn_mf_fnc_sites_aa_reveal_targets;
-
-
-/*
-["sites_discovery_something_number", 100] call _fnc_load_from_params;
-["sites_discovery_something_bool", false, true] call _fnc_load_from_params;
-
-
-private _fnc_load_bool_from_params = {
-    params [
-        ["_param_key", "", ""],
-        ["_default_value", false, true]
-    ];
-
-    [false, true] select ([param_key, [0, 1] select _default_value] call BIS_fnc_getParamValue);
-
-};
-*/

--- a/mission/functions/systems/sites/fn_sites_init.sqf
+++ b/mission/functions/systems/sites/fn_sites_init.sqf
@@ -22,12 +22,17 @@ vn_mf_s_max_fortifications_per_zone = getNumber (missionConfigFile >> "map_confi
 vn_mf_s_max_tunnels_per_zone = getNumber (missionConfigFile >> "map_config" >> "max_tunnels_per_zone");
 vn_mf_s_max_vehicle_depots_per_zone = getNumber (missionConfigFile >> "map_config" >> "max_vehicle_depots_per_zone");
 
-vn_mf_g_sites_partial_discovery_radius = 300;
+
+vn_mf_g_sites_partial_discovery_radius = ["sites_partial_discovery_radius_meters", 300] call BIS_fnc_getParamValue;
 publicVariable "vn_mf_g_sites_partial_discovery_radius";
-vn_mf_g_sites_discovery_radius = 50;
+
+vn_mf_g_sites_discovery_radius = ["sites_discovery_radius_meters", 50] call BIS_fnc_getParamValue;
 publicVariable "vn_mf_g_sites_discovery_radius";
-vn_mf_g_sites_scout_action_cooldown = 30;
+
+vn_mf_g_sites_scout_action_cooldown = ["sites_scout_action_cooldown_seconds", 30] call BIS_fnc_getParamValue;
 publicVariable "vn_mf_g_sites_scout_action_cooldown";
+
+vn_mf_s_sites_discovery_aa_marker_enabled = [false, true] select (["sites_discovery_aa_marker_toggle", 1] call BIS_fnc_getParamValue);
 
 missionNamespace setVariable ["sites", []];
 publicVariable "sites";
@@ -41,3 +46,20 @@ if !(_loadSuccessful) then
 };
 
 [] call vn_mf_fnc_sites_aa_reveal_targets;
+
+
+/*
+["sites_discovery_something_number", 100] call _fnc_load_from_params;
+["sites_discovery_something_bool", false, true] call _fnc_load_from_params;
+
+
+private _fnc_load_bool_from_params = {
+    params [
+        ["_param_key", "", ""],
+        ["_default_value", false, true]
+    ];
+
+    [false, true] select ([param_key, [0, 1] select _default_value] call BIS_fnc_getParamValue);
+
+};
+*/

--- a/mission/functions/systems/sites/fn_sites_subsystem_client_init.sqf
+++ b/mission/functions/systems/sites/fn_sites_subsystem_client_init.sqf
@@ -16,6 +16,12 @@
         [] call vn_mf_fnc_sites_client_init
 */
 
+vn_mf_c_sites_partial_discovery_marker_alpha_percent = (["sites_partial_discovery_marker_alpha_percent", 30] call BIS_fnc_getParamValue) / 100;
+vn_mf_c_sites_discovery_marker_alpha_percent = (["sites_discovery_marker_alpha_percent", 50] call BIS_fnc_getParamValue) / 100;
+
+private _toggle_site_discovery = [false, true] select (["sites_passive_discovery_toggle", 1] call BIS_fnc_getParamValue);
+if (!_toggle_site_discovery) exitWith {true};
+
 /*
     The marker discovery system allows site markers to be discovered thru passive exploration of the map
     as well as thru active scouting. 

--- a/mission/functions/systems/tutorial/fn_tutorial_subsystem_client_init.sqf
+++ b/mission/functions/systems/tutorial/fn_tutorial_subsystem_client_init.sqf
@@ -38,9 +38,10 @@
 */
 
 private _tutorialEnabled = ["para_enableTutorial"] call para_c_fnc_optionsMenu_getValue;
+private _tutorialGlobalEnabled = ["toggle_global_tutorials", 0] call BIS_fnc_getParamValue > 0;
 
 // Early exit if the tutorial is disabled
-if (!_tutorialEnabled) exitWith {
+if (!_tutorialEnabled || !_tutorialGlobalEnabled) exitWith {
 	//systemChat "Tutorial Disabled";
 	false;
 };

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_subsystem_init.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_subsystem_init.sqf
@@ -21,18 +21,18 @@ if (isNil "vn_mf_veh_asset_spawn_points") then {
 };
 
 //Vehicles are marked as abandoned after 5 minutes.
-vn_mf_veh_asset_abandonedTimer = 300;
+vn_mf_veh_asset_abandonedTimer = ["veh_asset_abandoned_timer_seconds", 300] call BIS_fnc_getParamValue;
 //Vehicles must be X distance from spawn to be marked as abandoned
-vn_mf_veh_asset_abandonedMinDistance = 20;
+vn_mf_veh_asset_abandonedMinDistance = ["veh_asset_abandoned_min_distance", 300] call BIS_fnc_getParamValue;
 //Marker positions are updated every X seconds
-vn_mf_veh_asset_markerUpdateDelay = 60;
+vn_mf_veh_asset_markerUpdateDelay = ["veh_asset_marker_update_delay_seconds", 10] call BIS_fnc_getParamValue;
 vn_mf_veh_asset_markerLastUpdate = 0;
 //Lock all vehicles that go idle
-vn_mf_veh_asset_lock_all_idle_vehicles = true;
+vn_mf_veh_asset_lock_all_idle_vehicles = [false, true] select (["veh_asset_lock_idle_vehicles", 1] call BIS_fnc_getParamValue);
 //Vehicles that go idle in one of these areas are locked (simulation disabled)
 vn_mf_veh_asset_lock_idle_vehicle_markers = _lockIdleVehicleMarkers;
 //Time to re-lock a vehicle
-vn_mf_veh_asset_relock_time = 30;
+vn_mf_veh_asset_relock_time = ["veh_asset_relock_time_seconds", 30] call BIS_fnc_getParamValue;
 //The maximum distance from the spawn point at which a vehicle can be changed for another vehicle type.
 vn_mf_veh_asset_vehicle_change_max_distance = 10;
 publicVariable "vn_mf_veh_asset_vehicle_change_max_distance";

--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -38,6 +38,16 @@ publicVariable "vn_mf_traits_map";
 //Set whether the building system needs vehicles (fuel/repair/rearm, etc) nearby to build certain structures.
 para_l_buildables_require_vehicles = [false, true] select (["buildables_require_vehicles", 1] call BIS_fnc_getParamValue);
 publicVariable "para_l_buildables_require_vehicles";
+
+// @dijksterhuis: PR TODO: para_l tag?
+// am following the convention above, but probably should be para_g tag.
+para_l_basebuilding_enabled = [false, true] select (["toggle_building_systems", 1] call BIS_fnc_getParamValue);
+publicVariable "para_l_basebuilding_enabled";
+
+para_s_harass_enabled = [false, true] select (["ai_harass_enabled", 1] call BIS_fnc_getParamValue);
+// @dijksterhuis: PR TODO: requires paradigm changes, will have no effect if merged before changes made
+para_s_harassMinDelay = ["ai_harass_minimum_delay", 240] call BIS_fnc_getParamValue;
+
 vn_mf_dawnLength = ["dawn_length", 1200] call BIS_fnc_getParamValue;
 vn_mf_dayLength = ["day_length", 9000] call BIS_fnc_getParamValue;
 vn_mf_duskLength = ["dusk_length", 1200] call BIS_fnc_getParamValue;
@@ -45,16 +55,19 @@ vn_mf_nightLength = ["night_length", 1800] call BIS_fnc_getParamValue;
 
 //Set whether stamia is enabled
 vn_mf_param_enable_stamina = (["enable_stamina", 1] call BIS_fnc_getParamValue) > 0;
-vn_mf_param_set_stamina = (["set_stamina", 1] call BIS_fnc_getParamValue);
 publicVariable "vn_mf_param_enable_stamina";
+
+vn_mf_param_set_stamina = (["set_stamina", 1] call BIS_fnc_getParamValue);
 publicVariable "vn_mf_param_set_stamina";
 
 //Set whether withstand is always available.
 vn_revive_withstand_allow = (["always_allow_withstand", 1] call BIS_fnc_getParamValue) > 0;
 publicVariable "vn_revive_withstand_allow";
+
 //Set number of bandages needed to withstand.
 vn_revive_withstand_amount = 4;
 publicVariable "vn_revive_withstand_amount";
+
 //Set number of max players per team
 vn_mf_max_players_acav = ["max_players_acav", 99] call BIS_fnc_getParamValue;
 vn_mf_max_players_greenhornets = ["max_players_greenhornets", 99] call BIS_fnc_getParamValue;;
@@ -179,6 +192,10 @@ diag_log format ["VN MikeForce: Total Game Time - %1", para_g_totalgametime];
 ["save_time_elapsed", {call vn_mf_fnc_save_time_elapsed}, [], 5] call para_g_fnc_scheduler_add_job;
 
 // spawn buildables and init vars
+
+// WARNING: We need to enable the building system even if the `para_l_basebuilding_enabled`
+// variable (from the "basebuilding_system_enabled" parameter option) is set to FALSE,
+// otherwise systems like AI Harassment cannot find the para_g_bases variable.
 diag_log "VN MikeForce: Initialising building system";
 call para_s_fnc_building_system_init;
 
@@ -187,6 +204,15 @@ diag_log "VN MikeForce: Creating supply officers";
 {
     [_x] call vn_mf_fnc_create_supply_officer;
 } forEach vn_mf_markers_supply_officer_initial;
+
+/*
+@dijksterhuis: PR TODO: disabling config flag until paradigm PR created
+if (para_l_basebuilding_enabled) then {
+    diag_log "VN MikeForce: Starting building state tracker";
+    // building state tracking
+    ["building_state_tracker", {call para_s_fnc_building_state_tracker}, [], 60] call para_g_fnc_scheduler_add_job;
+};
+*/
 
 diag_log "VN MikeForce: Starting building state tracker";
 // building state tracking
@@ -272,9 +298,11 @@ diag_log "VN MikeForce: Initialising AI Objectives";
     ["hardAiLimit", ["hard_ai_limit", 80] call BIS_fnc_getParamValue]
 ] call para_s_fnc_ai_obj_subsystem_init;
 
-diag_log "VN MikeForce: Initialising Harass";
 // Start harassment subsystem. Depends on the AI subsystem.
-[] call para_s_fnc_harass_subsystem_init;
+if (para_s_harass_enabled) then {
+    diag_log "VN MikeForce: Initialising Harass";
+    [] call para_s_fnc_harass_subsystem_init;
+};
 
 diag_log "VN MikeForce: Initialising Vehicle Manager";
 // start vehicle asset management subsystem

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -727,281 +727,216 @@
     </Container>
     <Container name="params">
       <Key ID="STR_vn_mf_param_wipe_save">
-        <Original>==== Delete Save ====</Original>
-        <English>==== Delete Save ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_wipe_save_desc">
-        <Original>[WARNING] Deletes your saved game. This will delete all progress (ranks and map)!</Original>
-        <English>[WARNING] Deletes your saved game. This will delete all progress (ranks and map)!</English>
+        <Original>TOGGLE DELETE SAVE: [WARNING] Deletes your saved game; This will delete all progress (ranks and map)!</Original>
+        <English>TOGGLE DELETE SAVE: [WARNING] Deletes your saved game; This will delete all progress (ranks and map)!</English>
       </Key>
       <Key ID="STR_vn_mf_param_enable_ranks">
-        <Original>==== Enable Rank System [Under Development] ====</Original>
-        <English>==== Enable Rank System [Under Development] ====</English>
+        <Original>TOGGLE RANK SYSTEM: Restrict arsenal item availability based on player rank</Original>
+        <English>TOGGLE RANK SYSTEM: Restrict arsenal item availability based on player rank</English>
       </Key>
       <Key ID="STR_vn_mf_param_hard_ai_limit">
-        <Original>==== Hard AI Limit ====</Original>
-        <English>==== Hard AI Limit ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_hard_ai_limit_desc">
-        <Original>[High performance impact] The maximum number of AI the mission will ever have simultaneously.</Original>
-        <English>[High performance impact] The maximum number of AI the mission will ever have simultaneously.</English>
+        <Original>HARD AI LIMIT: Maximum number of AI the mission will ever spawn simultaneously [High performance impact]</Original>
+        <English>HARD AI LIMIT: Maximum number of AI the mission will ever spawn simultaneously [High performance impact]</English>
       </Key>
       <Key ID="STR_vn_mf_param_ai_scaling">
-        <Original>==== AI Quantity Scaling ====</Original>
-        <English>==== AI Quantity Scaling ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_ai_scaling_desc">
-        <Original>[High performance impact] Global AI scaling. Higher is more AI for everything, lower is less.</Original>
-        <English>[High performance impact] Global AI scaling. Higher is more AI for everything, lower is less.</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_enable_ranks_desc">
-        <Original>Restrict vehicles/weapons based on rank. Recommended to reduce griefing.</Original>
-        <English>Restrict vehicles/weapons based on rank. Recommended to reduce griefing.</English>
+        <Original>AI QUANTITY SCALING: Global AI scaling; Higher is more AI per objective, lower is less [High performance impact]</Original>
+        <English>AI QUANTITY SCALING: Global AI scaling; Higher is more AI per objective, lower is less [High performance impact]</English>
       </Key>
       <Key ID="STR_vn_mf_param_allow_map_markers">
-        <Original>==== Enable Map Markers ====</Original>
-        <English>==== Enable Map Markers ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_allow_map_markers_desc">
-        <Original>Toggle player map markers</Original>
-        <English>Toggle player map markers</English>
+        <Original>TOGGLE MAP MARKERS: Toggle mission's custom player/vehicle map markers</Original>
+        <English>TOGGLE MAP MARKERS: Toggle mission's custom player/vehicle map markers</English>
       </Key>
       <Key ID="STR_vn_mf_dawn_length">
-        <Original>==== Dawn Length ====</Original>
-        <English>==== Dawn Length ====</English>
+        <Original>DAWN LENGTH</Original>
+        <English>DAWN LENGTH</English>
       </Key>
       <Key ID="STR_vn_mf_day_length">
-        <Original>==== Day Length ====</Original>
-        <English>==== Day Length ====</English>
+        <Original>DAY LENGTH</Original>
+        <English>DAY LENGTH</English>
       </Key>
       <Key ID="STR_vn_mf_dusk_length">
-        <Original>==== Dusk Length ====</Original>
-        <English>==== Dusk Length ====</English>
+        <Original>DUSK LENGTH</Original>
+        <English>DUSK LENGTH</English>
       </Key>
       <Key ID="STR_vn_mf_night_length">
-        <Original>==== Night Length ==== </Original>
-        <English>==== Night Length ====</English>
+        <Original>NIGHT LENGTH</Original>
+        <English>NIGHT LENGTH</English>
       </Key>
       <Key ID="STR_vn_mf_buildables_require_vehicles">
-        <Original>==== Resupply buildings require vehicles ====</Original>
-        <English>==== Resupply buildings require vehicles ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_buildables_require_vehicles_desc">
-        <Original>Should vehicles be required to build resupply buildings [Not Advised].</Original>
-        <English>Should vehicles be required to build resupply buildings [Not Advised].</English>
+        <Original>TOGGLE BUILDING RESUPPLY REQUIRES VEHICLES: Should vehicles be required to build resupply buildings [Not Advised].</Original>
+        <English>TOGGLE BUILDING RESUPPLY REQUIRES VEHICLES: Should vehicles be required to build resupply buildings [Not Advised].</English>
       </Key>
       <Key ID="STR_vn_mf_ai_quantity">
         <Original>==== AI Quantity ====</Original>
         <English>==== AI Quantity ====</English>
       </Key>
       <Key ID="STR_vn_mf_always_allow_withstand">
-        <Original>==== Allow Withstanding ====</Original>
-        <English>==== Allow Withstanding ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_always_allow_withstand_desc">
-        <Original>Enable withstand with friendlies nearby</Original>
-        <English>Enable withstand with friendlies nearby</English>
+        <Original>TOGGLE WITHSTANDING: Players can withstand (revive themselves)</Original>
+        <English>TOGGLE WITHSTANDING: Players can withstand (revive themselves)</English>
       </Key>
       <Key ID="STR_vn_mf_building_sandbag_value">
-        <Original>==== Sandbag Supplies Quantity ====</Original>
-        <English>==== Sandbag Supplies Quantity ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_building_sandbag_value_desc">
-        <Original>The building supplies value of sandbags carried in the inventory.</Original>
-        <English>The building supplies value of sandbags carried in the inventory.</English>
+        <Original>SANDBAG RESUPPLY VALUE: Building resupply value when adding sandbags to a building.</Original>
+        <English>SANDBAG RESUPPLY VALUE: Building resupply value when adding sandbags to a building.</English>
       </Key>
       <Key ID="STR_vn_mf_advanced_revive">
-        <Original>==== Advanced Revive ====</Original>
-        <English>==== Advanced Revive ====</English>
+        <Original>TOGGLE ADVANCED REVIVE: Enables the S.O.G. Prairie Fire Advanced Medical module [RECOMMENDED]</Original>
+        <English>TOGGLE ADVANCED REVIVE: Enables the S.O.G. Prairie Fire Advanced Medical module [RECOMMENDED]</English>
       </Key>
-      <Key ID="STR_vn_mf_advanced_revive_desc">
-        <Original>Enable Advanced Revive (Recommended)</Original>
-        <English>Enable Advanced Revive (Recommended)</English>
-      </Key>
-
       <Key ID="STR_vn_mf_param_snake_header">
-        <Original>======== Snake Settings ========</Original>
-        <English>======== Snake Settings ========</English>
+        <Original>========================================== Snake ==========================================</Original>
+        <English>========================================== Snakes ==========================================</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_wounds_healing_header">
+        <Original>======== Wounds and Healing Settings ========</Original>
+        <English>======== Wounds and Healing Settings ========</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_hunger_thirst_header">
+        <Original>========================================== Consumables ==========================================</Original>
+        <English>========================================== Consumables ==========================================</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_stamina_header">
+        <Original>========================================== Stamina ==========================================</Original>
+        <English>========================================== Stamina ==========================================</English>
       </Key>
       <Key ID="STR_vn_mf_param_snake_bite_chance">
-        <Original>==== Bite Chance ====</Original>
-        <English>==== Bite Chance ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_snake_bite_chance_desc">
-        <Original>Percentage chance of being bitten</Original>
-        <English>Percentage chance of being bitten</English>
+        <Original>BITE CHANCE: Percentage chance of being bitten</Original>
+        <English>BITE CHANCE: Percentage chance of being bitten</English>
       </Key>
       <Key ID="STR_vn_mf_param_snake_bite_distance">
-        <Original>==== Bite Distance ====</Original>
-        <English>==== Bite Distance ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_snake_bite_distance_desc">
-        <Original>How close a snake must be to bite a player</Original>
-        <English>How close a snake must be to bite a player</English>
+        <Original>BITE DISTANCE: How close a snake must be to bite a player</Original>
+        <English>BITE DISTANCE: How close a snake must be to bite a player</English>
       </Key>
       <Key ID="STR_vn_mf_param_snake_bite_frequency">
-        <Original>==== Bite Frequency ====</Original>
-        <English>==== Bite Frequency ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_snake_bite_frequency_desc">
-        <Original>Minimum Amount of time between bites</Original>
-        <English>Minimum Amount of time between bites</English>
+        <Original>BITE FREQUENCY: Minimum Amount of time between bites</Original>
+        <English>BITE FREQUENCY: Minimum Amount of time between bites</English>
       </Key>
       <Key ID="STR_vn_mf_param_snake_bite_extra_time">
-        <Original>==== Ramp up Time ====</Original>
-        <English>==== Ramp up Time ====</English>
+        <Original>RAMP UP TIME: Amount of time with reduced chance of being bitten; Starts counting after bite frequency time has elapsed</Original>
+        <English>RAMP UP TIME: Amount of time with reduced chance of being bitten; Starts counting after bite frequency time has elapsed</English>
       </Key>
-      <Key ID="STR_vn_mf_param_snake_bite_extra_time_desc">
-        <Original>Amount of time with a reduced chance of being bitten. Starts counting after the bite frequency time has elapsed.</Original>
-        <English>Amount of time with a reduced chance of being bitten. Starts counting after the bite frequency time has elapsed.</English>
+      <Key ID="STR_vn_mf_param_misc_header">
+        <Original>========================================== Misc. ==========================================</Original>
+        <English>========================================== Misc. ==========================================</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_ai_header">
+        <Original>========================================== Enemy AI ==========================================</Original>
+        <English>========================================== Enemy AI ==========================================</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_building_header">
+        <Original>========================================== Building ==========================================</Original>
+        <English>========================================== Building ==========================================</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_daynight_length_header">
+        <Original>========================================== Time of Day Durations ==========================================</Original>
+        <English>========================================== Time of Day Durations ==========================================</English>
       </Key>
       <Key ID="STR_vn_mf_param_teams_header">
-        <Original>======== Team Settings ========</Original>
-        <English>======== Team Settings ========</English>
+        <Original>========================================== Players Per Team ==========================================</Original>
+        <English>========================================== Players Per Team ==========================================</English>
+      </Key>
+      <Key ID="STR_vn_mf_param_vnsupport_header">
+        <Original>========================================== Air/Arty Support Module ==========================================</Original>
+        <English>========================================== Air/Arty Support Module ==========================================</English>
       </Key>
       <Key ID="STR_vn_mf_max_players_acav">
-        <Original>==== Max players on ACAV ====</Original>
-        <English>==== Max players on ACAV ====</English>
+        <Original>MAX PLAYERS: ACAV</Original>
+        <English>MAX PLAYERS: ACAV</English>
       </Key>
       <Key ID="STR_vn_mf_max_players_greenhornets">
-        <Original>==== Max players on Green Hornets ====</Original>
-        <English>==== Max players on Green Hornets ====</English>
+        <Original>MAX PLAYERS: GREEN HORNETS</Original>
+        <English>MAX PLAYERS: GREEN HORNETS</English>
       </Key>
       <Key ID="STR_vn_mf_max_players_mikeforce">
-        <Original>==== Max players on Mike Force ====</Original>
-        <English>==== Max players on Mike Force ====</English>
+        <Original>MAX PLAYERS: MIKE FORCE</Original>
+        <English>MAX PLAYERS: MIKE FORCE</English>
       </Key>
       <Key ID="STR_vn_mf_max_players_spiketeam">
-        <Original>==== Max players on Spike Team ====</Original>
-        <English>==== Max players on Spike Team ====</English>
+        <Original>MAX PLAYERS: SPIKE TEAM</Original>
+        <English>MAX PLAYERS: SPIKE TEAM</English>
       </Key>
       <Key ID="STR_vn_mf_param_hunger_loss_rate">
-        <Original>==== Hunger Gain Rate ====</Original>
-        <English>==== Hunger Gain Rate ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_hunger_loss_rate_desc">
-        <Original>The percentage of the hunger bar lost every 10 seconds</Original>
-        <English>The percentage of the hunger bar lost every 10 seconds</English>
+        <Original>HUNGER RATE: The percentage of the hunger bar lost every 10 seconds</Original>
+        <English>HUNGER RATE: The percentage of the hunger bar lost every 10 seconds</English>
       </Key>
       <Key ID="STR_vn_mf_param_thirst_loss_rate">
-        <Original>==== Thirst Gain Rate ====</Original>
-        <English>==== Thirst Gain Rate ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_thirst_loss_rate_desc">
-        <Original>The percentage of the thirst bar lost every 10 seconds</Original>
-        <English>The percentage of the thirst bar lost every 10 seconds</English>
+        <Original>THIRST RATE: The percentage of the thirst bar lost every 10 seconds</Original>
+        <English>THIRST RATE: The percentage of the thirst bar lost every 10 seconds</English>
       </Key>
       <Key ID="STR_vn_mf_param_medical_header">
-        <Original>======== Medical Settings ========</Original>
-        <English>======== Medical Settings ========</English>
+        <Original>========================================== Advanced Revive ==========================================</Original>
+        <English>========================================== Advanced Revive ==========================================</English>
       </Key>
       <Key ID="STR_vn_mf_param_headshot_kill">
-        <Original>==== Headshots Kill ====</Original>
-        <English>==== Headshots Kill ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_headshot_kill_desc">
-        <Original>Toggle if headshots can cause instadeath</Original>
-        <English>Toggle if headshots can cause instadeath</English>
+        <Original>TOGGLE HEADSHOTS INSTAKILL: Toggle if headshots can cause instadeath for players</Original>
+        <English>TOGGLE HEADSHOTS INSTAKILL: Toggle if headshots can cause instadeath for players</English>
       </Key>
       <Key ID="STR_vn_mf_param_bleedout_time">
-        <Original>==== Bleedout Time ====</Original>
-        <English>==== Bleedout Time ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_bleedout_time_desc">
-        <Original>The time it takes in seconds for a wounded player to die</Original>
-        <English>The time it takes in seconds for a wounded player to die</English>
+        <Original>BLEEDOUT TIME: The time it takes in seconds for a wounded player to die once incapacitated</Original>
+        <English>BLEEDOUT TIME: The time it takes in seconds for a wounded player to die once incapacitated</English>
       </Key>
       <Key ID="STR_vn_mf_param_withstand_percentage">
-        <Original>==== Withstand Percentage ====</Original>
-        <English>==== Withstand Percentage ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_withstand_percentage_desc">
-        <Original>Percentage of bleedout time that must pass before withstanding is allowed</Original>
-        <English>Percentage of bleedout time that must pass before withstanding is allowed</English>
+        <Original>WITHSTAND PERCENTAGE: Percentage of bleedout time that must pass before withstanding is allowed</Original>
+        <English>WITHSTAND PERCENTAGE: Percentage of bleedout time that must pass before withstanding is allowed</English>
       </Key>
       <Key ID="STR_vn_mf_param_remove_bandage_item">
-        <Original>==== Remove Bandage Item ====</Original>
-        <English>==== Remove Bandage Item ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_remove_bandage_item_desc">
-        <Original>Remove the item used to stabilize a patient</Original>
-        <English>Remove the item used to stabilize a patient</English>
+        <Original>TOGGLE REMOVE BANDAGE ITEM: Remove the item used to stabilize a patient (does not remove Medikits)</Original>
+        <English>TOGGLE REMOVE BANDAGE ITEM: Remove the item used to stabilize a patient (does not remove Medikits)</English>
       </Key>
       <Key ID="STR_vn_mf_param_remove_revive_item">
-        <Original>==== Remove Revive Item ====</Original>
-        <English>==== Remove Revive Item ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_remove_revive_item_desc">
-        <Original>Remove the item used to revive a patient</Original>
-        <English>Remove the item used to revive a patient</English>
+        <Original>TOGGLE REMOVE REVIVE ITEM: Remove the item used to rescucitate a patient (does not remove Medikits)</Original>
+        <English>TOGGLE REMOVE REVIVE ITEM: Remove the item used to rescucitate a patient (does not remove Medikits)</English>
       </Key>
       <Key ID="STR_vn_mf_param_revive_requirement">
-        <Original>==== Require Medic to Revive ====</Original>
-        <English>==== Require Medic to Revive ====</English>
+        <Original>TOGGLE MEDIC ROLE REQUIRED: Players need the 'Medic' role to fully rescucitate patients</Original>
+        <English>TOGGLE MEDIC ROLE REQUIRED: Players need the 'Medic' role to fully rescucitate patients</English>
       </Key>
       <Key ID="STR_vn_mf_param_respawn_delay">
-        <Original>==== Respawn Delay ====</Original>
-        <English>==== Respawn Delay ====</English>
+        <Original>RESPAWN DELAY: How long a player has to wait before respawning</Original>
+        <English>RESPAWN DELAY: How long a player has to wait before respawning</English>
       </Key>
       <Key ID="STR_vn_mf_enable_air_support">
-        <Original>==== Enable RTO Air Support ====</Original>
-        <English>==== Enable RTO Air Support  ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_enable_air_support_desc">
-        <Original>Unique supports only will disable support from fast air and rotary wing units</Original>
-        <English>Unique supports only will disable support from fast air and rotary wing units</English>
+        <Original>TOGGLE RTO AIR SUPPORT: 'Unique Supports Only' disables support from fast air and rotary wing units</Original>
+        <English>TOGGLE RTO AIR SUPPORT: 'Unique Supports Only' disables support from fast air and rotary wing units</English>
       </Key>
       <Key ID="STR_vn_mf_enable_arty_support">
-        <Original>==== Enable RTO Artillery Support ====</Original>
-        <English>==== Enable RTO Artillery Support ====</English>
+        <Original>TOGGLE RTO ARTILLERY SUPPORT</Original>
+        <English>TOGGLE RTO ARTILLERY SUPPORT</English>
       </Key>
       <Key ID="STR_vn_mf_param_enable_stamina">
-        <Original>==== Enable Stamina ====</Original>
-        <English>==== Enable Stamina ====</English>
+        <Original>TOGGLE STAMINA</Original>
+        <English>TOGGLE STAMINA</English>
       </Key>
       <Key ID="STR_vn_mf_param_set_stamina">
-        <Original>==== Stamina Setting ====</Original>
-        <English>==== Stamina Setting ====</English>
+        <Original>STAMINA SCHEME: The Arma3 stamina scheme used by the mission</Original>
+        <English>STAMINA SCHEME: The Arma3 stamina scheme used by the mission</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_header">
-        <Original>======== Cleanup Settings ========</Original>
-        <English>======== Cleanup Settings ========</English>
+        <Original>========================================== Clean Up ==========================================</Original>
+        <English>========================================== Clean Up ==========================================</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_min_player_distance">
-        <Original>==== Cleanup Distance ====</Original>
-        <English>==== Cleanup Distance ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_cleanup_min_player_distance_desc">
-        <Original>Prevents deletion for certain objects, if a player is within X metres</Original>
-        <English>Prevents deletion for certain objects, if a player is within X metres</English>
+        <Original>CLEAN UP DISTANCE: Prevents deletion of certain objects if a player is within X metres</Original>
+        <English>CLEAN UP DISTANCE: Prevents deletion of certain objects if a player is within X metres</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_max_bodies">
-        <Original>==== Max Bodies ====</Original>
-        <English>==== Max Bodies ====</English>
+        <Original>MAX BODIES: Number of dead AI unit bodies to allow until performing a cleanup</Original>
+        <English>MAX BODIES: Number of dead AI unit bodies to allow until performing a cleanup</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_placed_gear">
-        <Original>==== Cleanup Placed Equipment ====</Original>
-        <English>==== Cleanup Placed Equipment ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_cleanup_placed_gear_desc">
-        <Original>Enables deleting equipment placed on the ground by players.</Original>
-        <English>Enables deleting equipment placed on the ground by players.</English>
+        <Original>TOGGLE CLEAN UP PLACED EQUIPMENT: Clean up job will delete equipment placed on the ground by players</Original>
+        <English>TOGGLE CLEAN UP PLACED EQUIPMENT: Clean up job will delete equipment placed on the ground by players</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_placed_gear_lifetime">
-        <Original>==== Placed equipment minimum lifetime ====</Original>
-        <English>==== Placed equipment minimum lifetime ====</English>
+        <Original>MINIMUM LIFETIME PLACED EQUIPMENT: Minimum amount of time before placed equipment is deleted</Original>
+        <English>MINIMUM LIFETIME PLACED EQUIPMENT: Minimum amount of time before placed equipment is deleted</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_dropped_gear">
-        <Original>==== Cleanup Dropped Equipment ====</Original>
-        <English>==== Cleanup Dropped Equipment ====</English>
-      </Key>
-      <Key ID="STR_vn_mf_param_cleanup_dropped_gear_desc">
-        <Original>Minimum amount of time before placed equipment is deleted.</Original>
-        <English>Minimum amount of time before placed equipment is deleted.</English>
+        <Original>TOGGLE CLEAN UP DROPPED EQUIPMENT: Clean up job will delete equipment dropped on the ground by players</Original>
+        <English>TOGGLE CLEAN UP DROPPED EQUIPMENT: Clean up job will delete equipment dropped on the ground by players</English>
       </Key>
       <Key ID="STR_vn_mf_param_cleanup_dropped_gear_lifetime">
-        <Original>==== Dropped equipment minimum lifetime ====</Original>
-        <English>==== Dropped equipment minimum lifetime ====</English>
+        <Original>MINIMUM LIFETIME DROPPED EQUIPMENT: Minimum amount of time before dropped equipment is deleted</Original>
+        <English>MINIMUM LIFETIME DROPPED EQUIPMENT: Minimum amount of time before dropped equipment is deleted</English>
       </Key>
     </Container>
     <Container name="voteMenu">


### PR DESCRIPTION
#183 

Compresses UI elements
- One row per parameter option (with headings being the exception)
- Description text on the same line as the option itself

Adds Boilerplate macros for headers/toggles (enable/disable)

Reorganise options and sections

Updated some of the description help texts

Adds a bunch of new parameterisation options:
- Global tutorial disable
- Zones:
  - Concurrent active zones limit
  - Zone map marker alpha value (zone markers can be fully disabled)
- Sites:
  - Toggle passive site discovery
  - Choose site partial discovery radius
  - Choose site full discovery radius
  - Choose site partial discovery marker alpha
  - Choose site full discovery marker alpha
  - Disable AA AoE map markers when fully discovered (hashed area markers)
  - Add extra scout cooldown options (up to 10 minutes)
- AI Harassment:
  - Add option to disable AI harassment
  - Configure minimum time to spawn AI harassment teams
  - Whether to allow AI harassment teams inside zones
- Enable/Disable build systems (needs another paradigm PR)
- Vehicle asset manager:
  - Vehicle abandoned timer settings
  - Vehicle abandoned min distance from spawn settings
  - Enable/Disable locking of idle vehicles
  - Time to relock idle vehicles
  - How often to update vehicle positions on map (need to test this)
- Advanced Revive, added a bunch of available `missionNamespace` variables

![image](https://github.com/user-attachments/assets/1aa1f012-18b3-4602-94a4-88eeaee5a3b3)

![image](https://github.com/user-attachments/assets/8df5d331-dac9-43d1-964d-4bbb965a8d1e)

![image](https://github.com/user-attachments/assets/c36b7d15-fb37-4404-b985-31fde6d4f8c9)

### TODO

- [ ] Add new Stringtable entries.
- [ ] Delete old description/subheading Stringtable entries.
- [ ] make sure every `Default` option is documented
- [ ] description texts for all options
- [ ] add remaining adv_revive `missionNamespace` options
- [ ] vn_artillery config options from here instead of config file?
- [ ] the bra mission.sqm needs the presence condition for advanced revive module added.
- [ ] sites -- configure the max random distance from site pos for markers?
- [ ] paradigm PR for ai harassment min delay option
- [ ] paradigm PR for disabling build system
- [ ] helper function to load booleans variable from 0/1 parameter values (see below)
```sqf
// ["sites_discovery_something_bool", false] call _fnc_load_from_params;
params [
    ["_param_key", "", ""],
    ["_default_value", false, true]
];
[false, true] select ([param_key, [0, 1] select _default_value] call BIS_fnc_getParamValue);
```