### PR TITLE
Fix: Set player direction correctly on initial spawn and after teleporting

### DIFF
--- a/mission/functions/systems/teleport/fn_teleport.sqf
+++ b/mission/functions/systems/teleport/fn_teleport.sqf
@@ -38,3 +38,5 @@ if (_newLocation isEqualTo []) then {_newLocation = _destination};
 remoteExecCall ["vn_mf_fnc_display_location_time",_player];
 
 _player setPos _newLocation;
+// set player's direction to match respawn marker direction
+_player setDir markerDir getText (_destinationConfig >> "position_marker");

--- a/mission/para_player_init_server.sqf
+++ b/mission/para_player_init_server.sqf
@@ -104,6 +104,8 @@ if !(rank _player isEqualTo _rank) then
 private _playerGroup = _player getVariable ["vn_mf_db_player_group", "MikeForce"];
 private _respawnMarker = format ["mf_respawn_%1", _playerGroup];
 _player setPos getMarkerPos _respawnMarker;
+// set player's direction to match the direction of the respawn marker
+_player setDir markerDir _respawnMarker;
 
 // add event handlers from the harass subsystem.
 [_player] call para_s_fnc_harass_add_player_event_handlers;


### PR DESCRIPTION
Previously, whenever a player teleported they would retain their original pre-teleported direction. Meaning they would teleport to the spawn point and could be looking in any random direction (whatever direction they were looking in previously).

Also affects initial spawn in on server join.