### PR TITLE
Fixup #204 -- Map custom teleporters config.

### DIFF
--- a/maps/altis/map_config/init.hpp
+++ b/maps/altis/map_config/init.hpp
@@ -9,4 +9,7 @@ class map_config {
 	class zones {
 		#include "zones.hpp"
 	};
+	class teleporters {
+		#include "teleporters.hpp"
+	};
 };

--- a/mission/config/gamemode.hpp
+++ b/mission/config/gamemode.hpp
@@ -96,10 +96,6 @@ class gamemode
 	{
 		#include "subconfigs\vehicle_respawn_info.hpp"
 	};
-	class teleporters
-	{
-		#include "subconfigs\teleporters.hpp"
-	};
 	class interaction_overlay
 	{
 		#include "subconfigs\interaction_overlay.hpp"


### PR DESCRIPTION
Fixes #204 

- Missing teleporters subclass include for altis.
- Leftover teleporters config include in gamemode config.

I swear, it's always the ones where i say to myself 'that's an easy and simple change i won't need to test, it's so simple and easy, what could i do wrong here...'.