### PR TITLE
ArsenalsInit: Initialise arsenals (markers/trashcan init) during server init

### DIFF
--- a/maps/altis/mission.sqm
+++ b/maps/altis/mission.sqm
@@ -6,6 +6,10 @@ class EditorData
 	scaleGridStep=1;
 	autoGroupingDist=10;
 	toggles=521;
+	mods[]=
+	{
+		"3denEnhanced"
+	};
 	class ItemIDProvider
 	{
 		nextID=1359;
@@ -16,18 +20,18 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=521;
+		nextID=551;
 	};
 	class Camera
 	{
 		pos[]={14479.979,34.028595,6175.1948};
 		dir[]={-0.43369952,-0.69989479,0.56750834};
 		up[]={-0.42497972,0.71424693,0.5560981};
-		aside[]={0.79455078,-2.750312e-008,0.60720921};
+		aside[]={0.79455078,-2.750312e-08,0.60720921};
 	};
 };
 binarizationWanted=0;
-sourceName="vn_mikeforce_indev";
+sourceName="vn_sgd_mikeforce_indev";
 addons[]=
 {
 	"modules_f_vietnam",
@@ -258,6 +262,24 @@ class CustomAttributes
 							};
 						};
 					};
+				};
+			};
+		};
+		nAttributes=1;
+	};
+	class Category1
+	{
+		name="Scenario";
+		class Attribute0
+		{
+			property="cba_settings_hasSettingsFile";
+			expression="false";
+			class Value
+			{
+				class data
+				{
+					singleType="BOOL";
+					value=1;
 				};
 			};
 		};
@@ -682,7 +704,7 @@ class Mission
 							b=-400;
 							angle=305.17801;
 							id=32;
-							atlOffset=-5.531311e-005;
+							atlOffset=-5.531311e-05;
 						};
 						class Item6
 						{
@@ -825,7 +847,7 @@ class Mission
 							b=-400;
 							angle=47.430981;
 							id=54;
-							atlOffset=4.3869019e-005;
+							atlOffset=4.3869019e-05;
 						};
 						class Item17
 						{
@@ -864,7 +886,7 @@ class Mission
 							b=-400;
 							angle=182.51788;
 							id=60;
-							atlOffset=-6.1035156e-005;
+							atlOffset=-6.1035156e-05;
 						};
 						class Item20
 						{
@@ -903,7 +925,7 @@ class Mission
 							b=-400;
 							angle=118.08148;
 							id=66;
-							atlOffset=-3.0517578e-005;
+							atlOffset=-3.0517578e-05;
 						};
 						class Item23
 						{
@@ -916,7 +938,7 @@ class Mission
 							b=-400;
 							angle=47.430981;
 							id=68;
-							atlOffset=9.1552734e-005;
+							atlOffset=9.1552734e-05;
 						};
 						class Item24
 						{
@@ -1079,7 +1101,7 @@ class Mission
 							text="MOLOS";
 							type="vn_flag_usa";
 							id=6;
-							atlOffset=-5.531311e-005;
+							atlOffset=-5.531311e-05;
 						};
 						class Item1
 						{
@@ -1089,7 +1111,7 @@ class Mission
 							text="MOLOS AIRFIELD";
 							type="vn_flag_usa";
 							id=11;
-							atlOffset=5.9127808e-005;
+							atlOffset=5.9127808e-05;
 						};
 						class Item2
 						{
@@ -1119,7 +1141,7 @@ class Mission
 							text="SOFIA";
 							type="vn_flag_vc";
 							id=13;
-							atlOffset=7.4386597e-005;
+							atlOffset=7.4386597e-05;
 						};
 						class Item5
 						{
@@ -1239,7 +1261,7 @@ class Mission
 							text="NEOCHORI";
 							type="vn_flag_vc";
 							id=51;
-							atlOffset=-2.1934509e-005;
+							atlOffset=-2.1934509e-05;
 						};
 						class Item17
 						{
@@ -1289,7 +1311,7 @@ class Mission
 							text="AGIOS DIONYSIOS";
 							type="vn_flag_vc";
 							id=61;
-							atlOffset=6.8664551e-005;
+							atlOffset=6.8664551e-05;
 						};
 						class Item22
 						{
@@ -1309,7 +1331,7 @@ class Mission
 							text="SYRTA";
 							type="vn_flag_vc";
 							id=65;
-							atlOffset=-3.0517578e-005;
+							atlOffset=-3.0517578e-05;
 						};
 						class Item24
 						{
@@ -1369,7 +1391,7 @@ class Mission
 							text="AGGELOCHORI";
 							type="vn_flag_vc";
 							id=79;
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 						};
 						class Item30
 						{
@@ -1379,7 +1401,7 @@ class Mission
 							text="PANOCHORI";
 							type="vn_flag_vc";
 							id=81;
-							atlOffset=6.4849854e-005;
+							atlOffset=6.4849854e-05;
 						};
 						class Item31
 						{
@@ -1429,7 +1451,7 @@ class Mission
 							text="NERI";
 							type="vn_flag_vc";
 							id=147;
-							atlOffset=-2.6702881e-005;
+							atlOffset=-2.6702881e-05;
 						};
 						class Item36
 						{
@@ -1625,7 +1647,7 @@ class Mission
 							type="mil_arrow";
 							angle=259.44424;
 							id=107;
-							atlOffset=-9.5367432e-007;
+							atlOffset=-9.5367432e-07;
 						};
 						class Item16
 						{
@@ -1680,7 +1702,7 @@ class Mission
 							type="mil_arrow";
 							angle=151.10997;
 							id=112;
-							atlOffset=-7.6293945e-006;
+							atlOffset=-7.6293945e-06;
 						};
 						class Item21
 						{
@@ -1735,7 +1757,7 @@ class Mission
 							type="mil_arrow";
 							angle=167.99493;
 							id=118;
-							atlOffset=5.531311e-005;
+							atlOffset=5.531311e-05;
 						};
 						class Item26
 						{
@@ -2171,7 +2193,7 @@ class Mission
 					name="Markers";
 					class Entities
 					{
-						items=4;
+						items=3;
 						class Item0
 						{
 							dataType="Marker";
@@ -2198,17 +2220,6 @@ class Mission
 							atlOffset=0.00016975403;
 						};
 						class Item2
-						{
-							dataType="Marker";
-							position[]={26915.873,99.130615,24312.705};
-							name="arsenal_mikeforce";
-							type="mil_dot";
-							colorName="ColorPink";
-							angle=131.91644;
-							id=320;
-							atlOffset=75.526108;
-						};
-						class Item3
 						{
 							dataType="Marker";
 							position[]={26917.385,23.615246,24313.822};
@@ -2355,7 +2366,7 @@ class Mission
 					};
 					id=191;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2390,7 +2401,7 @@ class Mission
 					};
 					id=192;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2425,7 +2436,7 @@ class Mission
 					};
 					id=193;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2460,7 +2471,7 @@ class Mission
 					};
 					id=195;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2530,7 +2541,7 @@ class Mission
 					};
 					id=198;
 					type="vn_sign_so_01";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2634,7 +2645,7 @@ class Mission
 					};
 					id=201;
 					type="Land_vn_bagfence_corner_f";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2704,7 +2715,7 @@ class Mission
 					};
 					id=203;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2739,7 +2750,7 @@ class Mission
 					};
 					id=204;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2774,7 +2785,7 @@ class Mission
 					};
 					id=205;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2809,7 +2820,7 @@ class Mission
 					};
 					id=206;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2878,7 +2889,7 @@ class Mission
 					};
 					id=208;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2913,7 +2924,7 @@ class Mission
 					};
 					id=209;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2948,7 +2959,7 @@ class Mission
 					};
 					id=210;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3126,7 +3137,7 @@ class Mission
 					};
 					id=214;
 					type="Land_vn_steeldrum_closed_04";
-					atlOffset=1.1444092e-005;
+					atlOffset=1.1444092e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3161,7 +3172,7 @@ class Mission
 					};
 					id=215;
 					type="Land_vn_cncbarriermedium_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3231,7 +3242,7 @@ class Mission
 					};
 					id=217;
 					type="Land_vn_lampshabby_f_dir_far";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3266,7 +3277,7 @@ class Mission
 					};
 					id=218;
 					type="Land_vn_lampshabby_f_dir_normal";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3368,7 +3379,7 @@ class Mission
 					};
 					id=221;
 					type="vn_sign_town_b_04_01";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3403,7 +3414,7 @@ class Mission
 					};
 					id=226;
 					type="Land_vn_bagfence_short_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3438,7 +3449,7 @@ class Mission
 					};
 					id=227;
 					type="Land_vn_bagfence_short_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3543,7 +3554,7 @@ class Mission
 					};
 					id=230;
 					type="Land_vn_bagfence_long_f";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3578,7 +3589,7 @@ class Mission
 					};
 					id=231;
 					type="Land_vn_bagfence_long_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3716,7 +3727,7 @@ class Mission
 					};
 					id=238;
 					type="Land_BagFence_Short_F";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3751,7 +3762,7 @@ class Mission
 					};
 					id=239;
 					type="Land_BagFence_Short_F";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3820,7 +3831,7 @@ class Mission
 					};
 					id=241;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4128,7 +4139,7 @@ class Mission
 					};
 					id=250;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4163,7 +4174,7 @@ class Mission
 					};
 					id=251;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4235,7 +4246,7 @@ class Mission
 					};
 					id=257;
 					type="Land_FilePhotos_F";
-					atlOffset=3.8146973e-005;
+					atlOffset=3.8146973e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4271,7 +4282,7 @@ class Mission
 					};
 					id=258;
 					type="Land_PencilRed_F";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4649,7 +4660,7 @@ class Mission
 					};
 					id=284;
 					type="Land_vn_b_trench_revetment_tall_09";
-					atlOffset=-1.9073486e-006;
+					atlOffset=-1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4684,7 +4695,7 @@ class Mission
 					};
 					id=286;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -4787,7 +4798,7 @@ class Mission
 					};
 					id=291;
 					type="Land_vn_b_trench_revetment_tall_03";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -5016,7 +5027,7 @@ class Mission
 					};
 					id=306;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -5052,7 +5063,7 @@ class Mission
 					};
 					id=307;
 					type="Land_vn_object_trashcan_01";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 				};
 				class Item88
 				{
@@ -5070,7 +5081,7 @@ class Mission
 					};
 					id=310;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -5123,7 +5134,7 @@ class Mission
 					};
 					id=313;
 					type="Land_Billboard_03_aan_F";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -5158,7 +5169,7 @@ class Mission
 					};
 					id=315;
 					type="Land_vn_barracks_01_grey_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 				};
 				class Item92
 				{
@@ -5235,7 +5246,7 @@ class Mission
 							};
 							id=1153;
 							type="vn_b_wheeled_m151_01";
-							atlOffset=-7.0571899e-005;
+							atlOffset=-7.0571899e-05;
 						};
 						class Item2
 						{
@@ -5253,7 +5264,7 @@ class Mission
 							};
 							id=1154;
 							type="vn_b_wheeled_m151_02";
-							atlOffset=-4.196167e-005;
+							atlOffset=-4.196167e-05;
 						};
 					};
 					id=326;
@@ -5265,7 +5276,7 @@ class Mission
 					name="Markers";
 					class Entities
 					{
-						items=11;
+						items=10;
 						class Item0
 						{
 							dataType="Marker";
@@ -5290,16 +5301,6 @@ class Mission
 						class Item2
 						{
 							dataType="Marker";
-							position[]={27210.727,25.669451,24895.006};
-							name="arsenal_greenhornets";
-							type="mil_dot";
-							colorName="ColorPink";
-							angle=307.13516;
-							id=188;
-						};
-						class Item3
-						{
-							dataType="Marker";
 							position[]={26687.322,19.191999,24628.027};
 							name="duty_officer_greenhornets";
 							type="mil_dot";
@@ -5308,7 +5309,7 @@ class Mission
 							id=255;
 							atlOffset=-0.00012969971;
 						};
-						class Item4
+						class Item3
 						{
 							dataType="Marker";
 							position[]={26992.895,22.991142,24857.869};
@@ -5318,7 +5319,7 @@ class Mission
 							id=682;
 							atlOffset=0.59248734;
 						};
-						class Item5
+						class Item4
 						{
 							dataType="Marker";
 							position[]={26960.594,22.991142,24821.242};
@@ -5328,7 +5329,7 @@ class Mission
 							id=681;
 							atlOffset=1.1736774;
 						};
-						class Item6
+						class Item5
 						{
 							dataType="Marker";
 							position[]={26917.328,7.7075424,24802.563};
@@ -5339,7 +5340,7 @@ class Mission
 							id=1037;
 							atlOffset=-12.983318;
 						};
-						class Item7
+						class Item6
 						{
 							dataType="Marker";
 							position[]={26978.529,21.049011,24812.734};
@@ -5347,7 +5348,7 @@ class Mission
 							type="mil_dot";
 							id=1119;
 						};
-						class Item8
+						class Item7
 						{
 							dataType="Marker";
 							position[]={27272.293,29.755127,24918.732};
@@ -5359,17 +5360,17 @@ class Mission
 							id=1083;
 							atlOffset=0.70321465;
 						};
-						class Item9
+						class Item8
 						{
 							dataType="Marker";
 							position[]={27261.891,28.70002,24929.607};
 							name="supply_officer_initial_2";
 							text="Initial Supply Officer 2";
 							type="Empty";
-							angle=46.721527;
+							angle=46.721523;
 							id=1082;
 						};
-						class Item10
+						class Item9
 						{
 							dataType="Marker";
 							position[]={26918.277,18.671898,24801.551};
@@ -5475,7 +5476,7 @@ class Mission
 					};
 					id=572;
 					type="Land_HelipadSquare_F";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -5755,7 +5756,7 @@ class Mission
 					};
 					id=657;
 					type="Land_HelipadSquare_F";
-					atlOffset=-3.8146973e-006;
+					atlOffset=-3.8146973e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -5965,7 +5966,7 @@ class Mission
 					};
 					id=561;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6000,7 +6001,7 @@ class Mission
 					};
 					id=562;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6105,7 +6106,7 @@ class Mission
 					};
 					id=565;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6140,7 +6141,7 @@ class Mission
 					};
 					id=566;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6210,7 +6211,7 @@ class Mission
 					};
 					id=568;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6280,7 +6281,7 @@ class Mission
 					};
 					id=570;
 					type="Land_vn_lampshabby_f_4xdir_normal";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6488,7 +6489,7 @@ class Mission
 					};
 					id=622;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6523,7 +6524,7 @@ class Mission
 					};
 					id=624;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6558,7 +6559,7 @@ class Mission
 					};
 					id=625;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6593,7 +6594,7 @@ class Mission
 					};
 					id=626;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6628,7 +6629,7 @@ class Mission
 					};
 					id=628;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6663,7 +6664,7 @@ class Mission
 					};
 					id=629;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6698,7 +6699,7 @@ class Mission
 					};
 					id=630;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6733,7 +6734,7 @@ class Mission
 					};
 					id=631;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6838,7 +6839,7 @@ class Mission
 					};
 					id=634;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6873,7 +6874,7 @@ class Mission
 					};
 					id=635;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6908,7 +6909,7 @@ class Mission
 					};
 					id=636;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=-1.9073486e-006;
+					atlOffset=-1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6943,7 +6944,7 @@ class Mission
 					};
 					id=637;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7116,7 +7117,7 @@ class Mission
 					};
 					id=642;
 					type="Land_vn_usaf_revetment_low_3";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7185,7 +7186,7 @@ class Mission
 					};
 					id=548;
 					type="Land_vn_usaf_revetment_2";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7255,7 +7256,7 @@ class Mission
 					};
 					id=579;
 					type="Land_vn_usaf_revetment_2";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7290,7 +7291,7 @@ class Mission
 					};
 					id=580;
 					type="Land_vn_usaf_revetment_2";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7325,7 +7326,7 @@ class Mission
 					};
 					id=590;
 					type="Land_vn_usaf_revetment_8";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7395,7 +7396,7 @@ class Mission
 					};
 					id=592;
 					type="Land_vn_usaf_revetment_8";
-					atlOffset=9.5367432e-006;
+					atlOffset=9.5367432e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7675,7 +7676,7 @@ class Mission
 					};
 					id=601;
 					type="Land_vn_usaf_revetment_8";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7710,7 +7711,7 @@ class Mission
 					};
 					id=602;
 					type="Land_vn_usaf_revetment_8";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7779,7 +7780,7 @@ class Mission
 					};
 					id=605;
 					type="Land_vn_usaf_revetment_8";
-					atlOffset=2.4795532e-005;
+					atlOffset=2.4795532e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7969,7 +7970,7 @@ class Mission
 							};
 							id=525;
 							type="Land_vn_usaf_fueltank_75_01";
-							atlOffset=5.7220459e-006;
+							atlOffset=5.7220459e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -8142,7 +8143,7 @@ class Mission
 							};
 							id=550;
 							type="Land_vn_usaf_fueltank_75_01";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -8177,7 +8178,7 @@ class Mission
 							};
 							id=552;
 							type="Land_vn_usaf_fueltank_75_01";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -8450,7 +8451,7 @@ class Mission
 							};
 							id=671;
 							type="Land_vn_usaf_fueltank_75_01";
-							atlOffset=9.5367432e-006;
+							atlOffset=9.5367432e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -8485,7 +8486,7 @@ class Mission
 							};
 							id=674;
 							type="Land_vn_usaf_fueltank_75_01";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -8520,7 +8521,7 @@ class Mission
 							};
 							id=676;
 							type="Land_vn_usaf_fueltank_75_01";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -9014,7 +9015,7 @@ class Mission
 					};
 					id=679;
 					type="Land_HelipadSquare_F";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -9494,7 +9495,7 @@ class Mission
 							};
 							id=815;
 							type="vn_b_army_static_m60_high";
-							atlOffset=-3.4332275e-005;
+							atlOffset=-3.4332275e-05;
 						};
 						class Item4
 						{
@@ -9511,7 +9512,7 @@ class Mission
 							};
 							id=814;
 							type="vn_b_army_static_m60_low";
-							atlOffset=1.9073486e-005;
+							atlOffset=1.9073486e-05;
 						};
 						class Item5
 						{
@@ -10064,7 +10065,7 @@ class Mission
 					};
 					id=818;
 					type="Land_vn_b_mortarpit_01";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10099,7 +10100,7 @@ class Mission
 					};
 					id=730;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=-4.196167e-005;
+					atlOffset=-4.196167e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10169,7 +10170,7 @@ class Mission
 					};
 					id=732;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10204,7 +10205,7 @@ class Mission
 					};
 					id=733;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10274,7 +10275,7 @@ class Mission
 					};
 					id=743;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=-3.8146973e-005;
+					atlOffset=-3.8146973e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10309,7 +10310,7 @@ class Mission
 					};
 					id=744;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=5.7220459e-006;
+					atlOffset=5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10449,7 +10450,7 @@ class Mission
 					};
 					id=750;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10484,7 +10485,7 @@ class Mission
 					};
 					id=751;
 					type="Land_vn_b_trench_20_01";
-					atlOffset=-6.1035156e-005;
+					atlOffset=-6.1035156e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -10834,7 +10835,7 @@ class Mission
 					};
 					id=737;
 					type="Land_vn_b_trench_end_01";
-					atlOffset=1.9073486e-006;
+					atlOffset=1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -11008,7 +11009,7 @@ class Mission
 					};
 					id=741;
 					type="Land_vn_b_trench_tee_01";
-					atlOffset=1.7166138e-005;
+					atlOffset=1.7166138e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -11148,7 +11149,7 @@ class Mission
 					};
 					id=735;
 					type="Land_vn_b_trench_firing_05";
-					atlOffset=6.4849854e-005;
+					atlOffset=6.4849854e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -11243,18 +11244,8 @@ class Mission
 					name="Markers";
 					class Entities
 					{
-						items=5;
+						items=4;
 						class Item0
-						{
-							dataType="Marker";
-							position[]={26533.881,18.784,24215.68};
-							name="arsenal_acav";
-							type="mil_dot";
-							colorName="ColorPink";
-							id=1120;
-							atlOffset=0.00028610229;
-						};
-						class Item1
 						{
 							dataType="Marker";
 							position[]={26563.23,18.709,24083.768};
@@ -11263,7 +11254,7 @@ class Mission
 							id=1118;
 							atlOffset=0.00044059753;
 						};
-						class Item2
+						class Item1
 						{
 							dataType="Marker";
 							position[]={26596.596,19.00296,24098.719};
@@ -11271,11 +11262,11 @@ class Mission
 							text="Initial Supply Drop 1";
 							type="Empty";
 							colorName="ColorOrange";
-							angle=225.49702;
+							angle=225.49701;
 							id=1058;
 							atlOffset=0.50146294;
 						};
-						class Item3
+						class Item2
 						{
 							dataType="Marker";
 							position[]={26563.191,18.708416,24083.693};
@@ -11285,7 +11276,7 @@ class Mission
 							angle=79.258224;
 							id=1059;
 						};
-						class Item4
+						class Item3
 						{
 							dataType="Marker";
 							position[]={26524.006,18.665039,24224.928};
@@ -11950,7 +11941,7 @@ class Mission
 					};
 					id=838;
 					type="Land_vn_b_prop_mapstand_01";
-					atlOffset=-5.9127808e-005;
+					atlOffset=-5.9127808e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12077,7 +12068,7 @@ class Mission
 					};
 					id=1132;
 					type="Land_vn_shed_06_f";
-					atlOffset=3.8146973e-006;
+					atlOffset=3.8146973e-06;
 				};
 				class Item78
 				{
@@ -12219,7 +12210,7 @@ class Mission
 					};
 					id=859;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.6266785e-005;
+					atlOffset=-5.6266785e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12256,7 +12247,7 @@ class Mission
 			{
 			};
 			id=858;
-			atlOffset=-5.6266785e-005;
+			atlOffset=-5.6266785e-05;
 		};
 		class Item14
 		{
@@ -12281,7 +12272,7 @@ class Mission
 					};
 					id=863;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.6266785e-005;
+					atlOffset=-5.6266785e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12318,7 +12309,7 @@ class Mission
 			{
 			};
 			id=862;
-			atlOffset=-5.6266785e-005;
+			atlOffset=-5.6266785e-05;
 		};
 		class Item15
 		{
@@ -12343,7 +12334,7 @@ class Mission
 					};
 					id=865;
 					type="vn_b_men_sf_06";
-					atlOffset=-8.3446503e-005;
+					atlOffset=-8.3446503e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12380,7 +12371,7 @@ class Mission
 			{
 			};
 			id=864;
-			atlOffset=-8.3446503e-005;
+			atlOffset=-8.3446503e-05;
 		};
 		class Item16
 		{
@@ -12405,7 +12396,7 @@ class Mission
 					};
 					id=867;
 					type="vn_b_men_sf_06";
-					atlOffset=3.695488e-005;
+					atlOffset=3.695488e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12442,7 +12433,7 @@ class Mission
 			{
 			};
 			id=866;
-			atlOffset=3.695488e-005;
+			atlOffset=3.695488e-05;
 		};
 		class Item17
 		{
@@ -12467,7 +12458,7 @@ class Mission
 					};
 					id=869;
 					type="vn_b_men_sf_06";
-					atlOffset=3.7193298e-005;
+					atlOffset=3.7193298e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12504,7 +12495,7 @@ class Mission
 			{
 			};
 			id=868;
-			atlOffset=3.7193298e-005;
+			atlOffset=3.7193298e-05;
 		};
 		class Item18
 		{
@@ -12591,7 +12582,7 @@ class Mission
 					};
 					id=873;
 					type="vn_b_men_sf_06";
-					atlOffset=-9.226799e-005;
+					atlOffset=-9.226799e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12628,7 +12619,7 @@ class Mission
 			{
 			};
 			id=872;
-			atlOffset=-9.226799e-005;
+			atlOffset=-9.226799e-05;
 		};
 		class Item20
 		{
@@ -12653,7 +12644,7 @@ class Mission
 					};
 					id=875;
 					type="vn_b_men_sf_06";
-					atlOffset=3.695488e-005;
+					atlOffset=3.695488e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12690,7 +12681,7 @@ class Mission
 			{
 			};
 			id=874;
-			atlOffset=3.695488e-005;
+			atlOffset=3.695488e-05;
 		};
 		class Item21
 		{
@@ -12715,7 +12706,7 @@ class Mission
 					};
 					id=877;
 					type="vn_b_men_sf_06";
-					atlOffset=3.7193298e-005;
+					atlOffset=3.7193298e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12752,7 +12743,7 @@ class Mission
 			{
 			};
 			id=876;
-			atlOffset=3.7193298e-005;
+			atlOffset=3.7193298e-05;
 		};
 		class Item22
 		{
@@ -12777,7 +12768,7 @@ class Mission
 					};
 					id=879;
 					type="vn_b_men_sf_06";
-					atlOffset=5.6028366e-005;
+					atlOffset=5.6028366e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12814,7 +12805,7 @@ class Mission
 			{
 			};
 			id=878;
-			atlOffset=5.6028366e-005;
+			atlOffset=5.6028366e-05;
 		};
 		class Item23
 		{
@@ -12901,7 +12892,7 @@ class Mission
 					};
 					id=883;
 					type="vn_b_men_sf_06";
-					atlOffset=3.6716461e-005;
+					atlOffset=3.6716461e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -12938,7 +12929,7 @@ class Mission
 			{
 			};
 			id=882;
-			atlOffset=3.6716461e-005;
+			atlOffset=3.6716461e-05;
 		};
 		class Item25
 		{
@@ -12963,7 +12954,7 @@ class Mission
 					};
 					id=885;
 					type="vn_b_men_sf_06";
-					atlOffset=3.6716461e-005;
+					atlOffset=3.6716461e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13000,7 +12991,7 @@ class Mission
 			{
 			};
 			id=884;
-			atlOffset=3.6716461e-005;
+			atlOffset=3.6716461e-05;
 		};
 		class Item26
 		{
@@ -13521,7 +13512,7 @@ class Mission
 					};
 					id=903;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.7683716e-005;
+					atlOffset=-4.7683716e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13558,7 +13549,7 @@ class Mission
 			{
 			};
 			id=902;
-			atlOffset=-4.7683716e-005;
+			atlOffset=-4.7683716e-05;
 		};
 		class Item35
 		{
@@ -13583,7 +13574,7 @@ class Mission
 					};
 					id=905;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.7206879e-005;
+					atlOffset=-4.7206879e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13620,7 +13611,7 @@ class Mission
 			{
 			};
 			id=904;
-			atlOffset=-4.7206879e-005;
+			atlOffset=-4.7206879e-05;
 		};
 		class Item36
 		{
@@ -13645,7 +13636,7 @@ class Mission
 					};
 					id=907;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.7206879e-005;
+					atlOffset=-4.7206879e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13682,7 +13673,7 @@ class Mission
 			{
 			};
 			id=906;
-			atlOffset=-4.7206879e-005;
+			atlOffset=-4.7206879e-05;
 		};
 		class Item37
 		{
@@ -13707,7 +13698,7 @@ class Mission
 					};
 					id=909;
 					type="vn_b_men_sf_06";
-					atlOffset=-8.058548e-005;
+					atlOffset=-8.058548e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13744,7 +13735,7 @@ class Mission
 			{
 			};
 			id=908;
-			atlOffset=-8.058548e-005;
+			atlOffset=-8.058548e-05;
 		};
 		class Item38
 		{
@@ -13769,7 +13760,7 @@ class Mission
 					};
 					id=911;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.7206879e-005;
+					atlOffset=-4.7206879e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13806,7 +13797,7 @@ class Mission
 			{
 			};
 			id=910;
-			atlOffset=-4.7206879e-005;
+			atlOffset=-4.7206879e-05;
 		};
 		class Item39
 		{
@@ -13831,7 +13822,7 @@ class Mission
 					};
 					id=913;
 					type="vn_b_men_sf_06";
-					atlOffset=-7.0095062e-005;
+					atlOffset=-7.0095062e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13868,7 +13859,7 @@ class Mission
 			{
 			};
 			id=912;
-			atlOffset=-7.0095062e-005;
+			atlOffset=-7.0095062e-05;
 		};
 		class Item40
 		{
@@ -13893,7 +13884,7 @@ class Mission
 					};
 					id=915;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.7206879e-005;
+					atlOffset=-4.7206879e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13930,7 +13921,7 @@ class Mission
 			{
 			};
 			id=914;
-			atlOffset=-4.7206879e-005;
+			atlOffset=-4.7206879e-05;
 		};
 		class Item41
 		{
@@ -13955,7 +13946,7 @@ class Mission
 					};
 					id=917;
 					type="vn_b_men_sf_06";
-					atlOffset=-7.9631805e-005;
+					atlOffset=-7.9631805e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -13992,7 +13983,7 @@ class Mission
 			{
 			};
 			id=916;
-			atlOffset=-7.9631805e-005;
+			atlOffset=-7.9631805e-05;
 		};
 		class Item42
 		{
@@ -14079,7 +14070,7 @@ class Mission
 					};
 					id=921;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.8160553e-005;
+					atlOffset=-4.8160553e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14116,7 +14107,7 @@ class Mission
 			{
 			};
 			id=920;
-			atlOffset=-4.8160553e-005;
+			atlOffset=-4.8160553e-05;
 		};
 		class Item44
 		{
@@ -14141,7 +14132,7 @@ class Mission
 					};
 					id=923;
 					type="vn_b_men_sf_06";
-					atlOffset=-7.9631805e-005;
+					atlOffset=-7.9631805e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14178,7 +14169,7 @@ class Mission
 			{
 			};
 			id=922;
-			atlOffset=-7.9631805e-005;
+			atlOffset=-7.9631805e-05;
 		};
 		class Item45
 		{
@@ -14203,7 +14194,7 @@ class Mission
 					};
 					id=925;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14240,7 +14231,7 @@ class Mission
 			{
 			};
 			id=924;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item46
 		{
@@ -14265,7 +14256,7 @@ class Mission
 					};
 					id=927;
 					type="vn_b_men_sf_06";
-					atlOffset=-7.9154968e-005;
+					atlOffset=-7.9154968e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14302,7 +14293,7 @@ class Mission
 			{
 			};
 			id=926;
-			atlOffset=-7.9154968e-005;
+			atlOffset=-7.9154968e-05;
 		};
 		class Item47
 		{
@@ -14327,7 +14318,7 @@ class Mission
 					};
 					id=929;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.2928925e-005;
+					atlOffset=-5.2928925e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14364,7 +14355,7 @@ class Mission
 			{
 			};
 			id=928;
-			atlOffset=-5.2928925e-005;
+			atlOffset=-5.2928925e-05;
 		};
 		class Item48
 		{
@@ -14389,7 +14380,7 @@ class Mission
 					};
 					id=931;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.2928925e-005;
+					atlOffset=-5.2928925e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14426,7 +14417,7 @@ class Mission
 			{
 			};
 			id=930;
-			atlOffset=-5.2928925e-005;
+			atlOffset=-5.2928925e-05;
 		};
 		class Item49
 		{
@@ -14451,7 +14442,7 @@ class Mission
 					};
 					id=933;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14488,7 +14479,7 @@ class Mission
 			{
 			};
 			id=932;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item50
 		{
@@ -14513,7 +14504,7 @@ class Mission
 					};
 					id=935;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.2928925e-005;
+					atlOffset=-5.2928925e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14550,7 +14541,7 @@ class Mission
 			{
 			};
 			id=934;
-			atlOffset=-5.2928925e-005;
+			atlOffset=-5.2928925e-05;
 		};
 		class Item51
 		{
@@ -14575,7 +14566,7 @@ class Mission
 					};
 					id=937;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14612,7 +14603,7 @@ class Mission
 			{
 			};
 			id=936;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item52
 		{
@@ -14637,7 +14628,7 @@ class Mission
 					};
 					id=939;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.2928925e-005;
+					atlOffset=-5.2928925e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14674,7 +14665,7 @@ class Mission
 			{
 			};
 			id=938;
-			atlOffset=-5.2928925e-005;
+			atlOffset=-5.2928925e-05;
 		};
 		class Item53
 		{
@@ -14699,7 +14690,7 @@ class Mission
 					};
 					id=941;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14736,7 +14727,7 @@ class Mission
 			{
 			};
 			id=940;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item54
 		{
@@ -14761,7 +14752,7 @@ class Mission
 					};
 					id=943;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.2928925e-005;
+					atlOffset=-5.2928925e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14798,7 +14789,7 @@ class Mission
 			{
 			};
 			id=942;
-			atlOffset=-5.2928925e-005;
+			atlOffset=-5.2928925e-05;
 		};
 		class Item55
 		{
@@ -14823,7 +14814,7 @@ class Mission
 					};
 					id=945;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14860,7 +14851,7 @@ class Mission
 			{
 			};
 			id=944;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item56
 		{
@@ -14885,7 +14876,7 @@ class Mission
 					};
 					id=947;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14922,7 +14913,7 @@ class Mission
 			{
 			};
 			id=946;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item57
 		{
@@ -14947,7 +14938,7 @@ class Mission
 					};
 					id=949;
 					type="vn_b_men_sf_06";
-					atlOffset=-5.3405762e-005;
+					atlOffset=-5.3405762e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -14984,7 +14975,7 @@ class Mission
 			{
 			};
 			id=948;
-			atlOffset=-5.3405762e-005;
+			atlOffset=-5.3405762e-05;
 		};
 		class Item58
 		{
@@ -15009,7 +15000,7 @@ class Mission
 					};
 					id=951;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.4822693e-005;
+					atlOffset=-4.4822693e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15046,7 +15037,7 @@ class Mission
 			{
 			};
 			id=950;
-			atlOffset=-4.4822693e-005;
+			atlOffset=-4.4822693e-05;
 		};
 		class Item59
 		{
@@ -15071,7 +15062,7 @@ class Mission
 					};
 					id=953;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.4822693e-005;
+					atlOffset=-4.4822693e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15108,7 +15099,7 @@ class Mission
 			{
 			};
 			id=952;
-			atlOffset=-4.4822693e-005;
+			atlOffset=-4.4822693e-05;
 		};
 		class Item60
 		{
@@ -15133,7 +15124,7 @@ class Mission
 					};
 					id=955;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.4345856e-005;
+					atlOffset=-4.4345856e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15170,7 +15161,7 @@ class Mission
 			{
 			};
 			id=954;
-			atlOffset=-4.4345856e-005;
+			atlOffset=-4.4345856e-05;
 		};
 		class Item61
 		{
@@ -15195,7 +15186,7 @@ class Mission
 					};
 					id=957;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.4822693e-005;
+					atlOffset=-4.4822693e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15232,7 +15223,7 @@ class Mission
 			{
 			};
 			id=956;
-			atlOffset=-4.4822693e-005;
+			atlOffset=-4.4822693e-05;
 		};
 		class Item62
 		{
@@ -15257,7 +15248,7 @@ class Mission
 					};
 					id=959;
 					type="vn_b_men_sf_06";
-					atlOffset=8.9168549e-005;
+					atlOffset=8.9168549e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15294,7 +15285,7 @@ class Mission
 			{
 			};
 			id=958;
-			atlOffset=8.9168549e-005;
+			atlOffset=8.9168549e-05;
 		};
 		class Item63
 		{
@@ -15319,7 +15310,7 @@ class Mission
 					};
 					id=961;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.4345856e-005;
+					atlOffset=-4.4345856e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15356,7 +15347,7 @@ class Mission
 			{
 			};
 			id=960;
-			atlOffset=-4.4345856e-005;
+			atlOffset=-4.4345856e-05;
 		};
 		class Item64
 		{
@@ -15381,7 +15372,7 @@ class Mission
 					};
 					id=963;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.4345856e-005;
+					atlOffset=-4.4345856e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15418,7 +15409,7 @@ class Mission
 			{
 			};
 			id=962;
-			atlOffset=-4.4345856e-005;
+			atlOffset=-4.4345856e-05;
 		};
 		class Item65
 		{
@@ -15443,7 +15434,7 @@ class Mission
 					};
 					id=965;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.529953e-005;
+					atlOffset=-4.529953e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15480,7 +15471,7 @@ class Mission
 			{
 			};
 			id=964;
-			atlOffset=-4.529953e-005;
+			atlOffset=-4.529953e-05;
 		};
 		class Item66
 		{
@@ -15505,7 +15496,7 @@ class Mission
 					};
 					id=967;
 					type="vn_b_men_sf_06";
-					atlOffset=8.9168549e-005;
+					atlOffset=8.9168549e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15542,7 +15533,7 @@ class Mission
 			{
 			};
 			id=966;
-			atlOffset=8.9168549e-005;
+			atlOffset=8.9168549e-05;
 		};
 		class Item67
 		{
@@ -15567,7 +15558,7 @@ class Mission
 					};
 					id=969;
 					type="vn_b_men_sf_06";
-					atlOffset=8.9168549e-005;
+					atlOffset=8.9168549e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15604,7 +15595,7 @@ class Mission
 			{
 			};
 			id=968;
-			atlOffset=8.9168549e-005;
+			atlOffset=8.9168549e-05;
 		};
 		class Item68
 		{
@@ -15629,7 +15620,7 @@ class Mission
 					};
 					id=971;
 					type="vn_b_men_sf_06";
-					atlOffset=-2.3841858e-005;
+					atlOffset=-2.3841858e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -15666,7 +15657,7 @@ class Mission
 			{
 			};
 			id=970;
-			atlOffset=-2.3841858e-005;
+			atlOffset=-2.3841858e-05;
 		};
 		class Item69
 		{
@@ -16250,7 +16241,7 @@ class Mission
 					};
 					id=1038;
 					type="Land_ToolTrolley_02_F";
-					atlOffset=3.4332275e-005;
+					atlOffset=3.4332275e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -16565,7 +16556,7 @@ class Mission
 					};
 					id=1047;
 					type="Land_ToolTrolley_01_F";
-					atlOffset=-1.9073486e-006;
+					atlOffset=-1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -16636,7 +16627,7 @@ class Mission
 					};
 					id=1049;
 					type="Land_WeldingTrolley_01_F";
-					atlOffset=-3.2424927e-005;
+					atlOffset=-3.2424927e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -16671,7 +16662,7 @@ class Mission
 					};
 					id=1050;
 					type="Land_vn_canister_ep1";
-					atlOffset=-1.9073486e-006;
+					atlOffset=-1.9073486e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -16814,7 +16805,7 @@ class Mission
 					};
 					id=1054;
 					type="vn_us_komex_medium_01";
-					atlOffset=-9.9182129e-005;
+					atlOffset=-9.9182129e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -16849,7 +16840,7 @@ class Mission
 					};
 					id=1055;
 					type="vn_us_komex_medium_02";
-					atlOffset=-5.7220459e-006;
+					atlOffset=-5.7220459e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -16878,7 +16869,7 @@ class Mission
 			name="Spike Team";
 			class Entities
 			{
-				items=7;
+				items=6;
 				class Item0
 				{
 					dataType="Marker";
@@ -16993,17 +16984,6 @@ class Mission
 					atlOffset=-0.28879166;
 				};
 				class Item5
-				{
-					dataType="Marker";
-					position[]={26950.012,97.488998,24300.26};
-					name="arsenal_spike_team";
-					type="mil_dot";
-					colorName="ColorPink";
-					angle=225.44173;
-					id=1127;
-					atlOffset=75.569992;
-				};
-				class Item6
 				{
 					dataType="Marker";
 					position[]={26947.609,21.974001,24301.393};
@@ -17175,7 +17155,7 @@ class Mission
 							};
 							id=1187;
 							type="vn_signad_sponsors_f";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17221,7 +17201,7 @@ class Mission
 							init="['air_transport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1189;
 							type="Logic";
-							atlOffset=1.335144e-005;
+							atlOffset=1.335144e-05;
 						};
 						class Item3
 						{
@@ -17239,7 +17219,7 @@ class Mission
 							};
 							id=1191;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17285,7 +17265,7 @@ class Mission
 							init="['air_transport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1193;
 							type="Logic";
-							atlOffset=2.6702881e-005;
+							atlOffset=2.6702881e-05;
 						};
 						class Item6
 						{
@@ -17365,7 +17345,7 @@ class Mission
 							};
 							id=1197;
 							type="vn_signad_sponsors_f";
-							atlOffset=3.0517578e-005;
+							atlOffset=3.0517578e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17411,7 +17391,7 @@ class Mission
 							init="['air_transport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1199;
 							type="Logic";
-							atlOffset=3.0517578e-005;
+							atlOffset=3.0517578e-05;
 						};
 						class Item12
 						{
@@ -17536,7 +17516,7 @@ class Mission
 							init="['air_transport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1223;
 							type="Logic";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 						};
 						class Item18
 						{
@@ -17554,7 +17534,7 @@ class Mission
 							};
 							id=1224;
 							type="vn_signad_sponsors_f";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17701,7 +17681,7 @@ class Mission
 							init="['air_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1217;
 							type="Logic";
-							atlOffset=1.335144e-005;
+							atlOffset=1.335144e-05;
 						};
 						class Item2
 						{
@@ -17719,7 +17699,7 @@ class Mission
 							};
 							id=1215;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17765,7 +17745,7 @@ class Mission
 							init="['air_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1214;
 							type="Logic";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 						};
 						class Item5
 						{
@@ -17828,7 +17808,7 @@ class Mission
 							init="['air_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1211;
 							type="Logic";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 						};
 						class Item8
 						{
@@ -17846,7 +17826,7 @@ class Mission
 							};
 							id=1209;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17910,7 +17890,7 @@ class Mission
 							init="['air_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1202;
 							type="Logic";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 						};
 						class Item11
 						{
@@ -17996,7 +17976,7 @@ class Mission
 							init="['air_heavy_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1208;
 							type="Logic";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 						};
 						class Item3
 						{
@@ -18259,7 +18239,7 @@ class Mission
 							init="['transport_light', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1253;
 							type="Logic";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 						};
 						class Item2
 						{
@@ -18293,7 +18273,7 @@ class Mission
 							};
 							id=1256;
 							type="vn_signad_sponsors_f";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18356,7 +18336,7 @@ class Mission
 							};
 							id=1259;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18386,7 +18366,7 @@ class Mission
 							init="['transport_light', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1260;
 							type="Logic";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 						};
 						class Item8
 						{
@@ -18431,7 +18411,7 @@ class Mission
 							};
 							id=1262;
 							type="vn_signad_sponsors_f";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18585,7 +18565,7 @@ class Mission
 							init="['transport_heavy', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1270;
 							type="Logic";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 						};
 						class Item8
 						{
@@ -18619,7 +18599,7 @@ class Mission
 							};
 							id=1272;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18649,7 +18629,7 @@ class Mission
 							init="['transport_heavy', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1273;
 							type="Logic";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 						};
 						class Item11
 						{
@@ -18818,7 +18798,7 @@ class Mission
 							};
 							id=1281;
 							type="vn_signad_sponsors_f";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18881,7 +18861,7 @@ class Mission
 							};
 							id=1285;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.7166138e-005;
+							atlOffset=1.7166138e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18911,7 +18891,7 @@ class Mission
 							init="['utility', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1286;
 							type="Logic";
-							atlOffset=1.9073486e-005;
+							atlOffset=1.9073486e-05;
 						};
 						class Item5
 						{
@@ -19018,7 +18998,7 @@ class Mission
 							};
 							id=1291;
 							type="vn_signad_sponsors_f";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -19048,7 +19028,7 @@ class Mission
 							init="['light_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1292;
 							type="Logic";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 						};
 						class Item2
 						{
@@ -19082,7 +19062,7 @@ class Mission
 							};
 							id=1295;
 							type="vn_signad_sponsors_f";
-							atlOffset=3.0517578e-005;
+							atlOffset=3.0517578e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -19112,7 +19092,7 @@ class Mission
 							init="['light_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1296;
 							type="Logic";
-							atlOffset=2.8610229e-005;
+							atlOffset=2.8610229e-05;
 						};
 						class Item5
 						{
@@ -19146,7 +19126,7 @@ class Mission
 							};
 							id=1298;
 							type="vn_signad_sponsors_f";
-							atlOffset=3.0517578e-005;
+							atlOffset=3.0517578e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -19176,7 +19156,7 @@ class Mission
 							init="['light_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1299;
 							type="Logic";
-							atlOffset=2.6702881e-005;
+							atlOffset=2.6702881e-05;
 						};
 						class Item8
 						{
@@ -19217,7 +19197,7 @@ class Mission
 									};
 									id=1301;
 									type="vn_signad_sponsors_f";
-									atlOffset=6.1035156e-005;
+									atlOffset=6.1035156e-05;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -19280,7 +19260,7 @@ class Mission
 									};
 									id=1305;
 									type="vn_signad_sponsors_f";
-									atlOffset=7.2479248e-005;
+									atlOffset=7.2479248e-05;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -19310,7 +19290,7 @@ class Mission
 									init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 									id=1306;
 									type="Logic";
-									atlOffset=1.1444092e-005;
+									atlOffset=1.1444092e-05;
 								};
 								class Item5
 								{
@@ -19344,7 +19324,7 @@ class Mission
 									};
 									id=1308;
 									type="vn_signad_sponsors_f";
-									atlOffset=8.2015991e-005;
+									atlOffset=8.2015991e-05;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -19374,7 +19354,7 @@ class Mission
 									init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 									id=1309;
 									type="Logic";
-									atlOffset=1.9073486e-005;
+									atlOffset=1.9073486e-05;
 								};
 								class Item8
 								{
@@ -19437,7 +19417,7 @@ class Mission
 									init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 									id=1338;
 									type="Logic";
-									atlOffset=1.9073486e-006;
+									atlOffset=1.9073486e-06;
 								};
 								class Item11
 								{
@@ -19471,7 +19451,7 @@ class Mission
 									};
 									id=1340;
 									type="vn_signad_sponsors_f";
-									atlOffset=8.392334e-005;
+									atlOffset=8.392334e-05;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -19501,7 +19481,7 @@ class Mission
 									init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 									id=1341;
 									type="Logic";
-									atlOffset=8.392334e-005;
+									atlOffset=8.392334e-05;
 								};
 								class Item14
 								{
@@ -19535,7 +19515,7 @@ class Mission
 									};
 									id=1343;
 									type="vn_signad_sponsors_f";
-									atlOffset=-1.9073486e-006;
+									atlOffset=-1.9073486e-06;
 									class CustomAttributes
 									{
 										class Attribute0
@@ -19613,7 +19593,7 @@ class Mission
 							};
 							id=1317;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -20195,7 +20175,7 @@ class Mission
 							};
 							id=1352;
 							type="vn_signad_sponsors_f";
-							atlOffset=6.8664551e-005;
+							atlOffset=6.8664551e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -20225,7 +20205,7 @@ class Mission
 							init="['utility_airport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1353;
 							type="Logic";
-							atlOffset=6.8664551e-005;
+							atlOffset=6.8664551e-05;
 						};
 						class Item8
 						{
@@ -20266,7 +20246,7 @@ class Mission
 			};
 			id=1244;
 			type="Land_vn_b_trench_revetment_tall_09";
-			atlOffset=-3.8146973e-006;
+			atlOffset=-3.8146973e-06;
 		};
 		class Item85
 		{

--- a/maps/altis/mission.sqm
+++ b/maps/altis/mission.sqm
@@ -20,14 +20,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=551;
+		nextID=581;
 	};
 	class Camera
 	{
-		pos[]={14479.979,34.028595,6175.1948};
-		dir[]={-0.43369952,-0.69989479,0.56750834};
-		up[]={-0.42497972,0.71424693,0.5560981};
-		aside[]={0.79455078,-2.750312e-08,0.60720921};
+		pos[]={0,25,-25};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710677,0.70710677};
+		aside[]={0.99999994,0,-0};
 	};
 };
 binarizationWanted=0;
@@ -262,24 +262,6 @@ class CustomAttributes
 							};
 						};
 					};
-				};
-			};
-		};
-		nAttributes=1;
-	};
-	class Category1
-	{
-		name="Scenario";
-		class Attribute0
-		{
-			property="cba_settings_hasSettingsFile";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					singleType="BOOL";
-					value=1;
 				};
 			};
 		};
@@ -2231,11 +2213,11 @@ class Mission
 						};
 					};
 					id=329;
-					atlOffset=18.878847;
+					atlOffset=-0.00071334839;
 				};
 			};
 			id=323;
-			atlOffset=-35.738907;
+			atlOffset=-45.190495;
 		};
 		class Item10
 		{
@@ -5367,7 +5349,7 @@ class Mission
 							name="supply_officer_initial_2";
 							text="Initial Supply Officer 2";
 							type="Empty";
-							angle=46.721523;
+							angle=46.721519;
 							id=1082;
 						};
 						class Item9
@@ -5387,7 +5369,7 @@ class Mission
 						};
 					};
 					id=327;
-					atlOffset=-0.25759506;
+					atlOffset=-0.25821877;
 				};
 				class Item95
 				{
@@ -11262,7 +11244,7 @@ class Mission
 							text="Initial Supply Drop 1";
 							type="Empty";
 							colorName="ColorOrange";
-							angle=225.49701;
+							angle=225.49699;
 							id=1058;
 							atlOffset=0.50146294;
 						};
@@ -11289,7 +11271,7 @@ class Mission
 						};
 					};
 					id=836;
-					atlOffset=-0.53775978;
+					atlOffset=-0.67098618;
 				};
 				class Item52
 				{
@@ -16996,7 +16978,7 @@ class Mission
 				};
 			};
 			id=1129;
-			atlOffset=18.776302;
+			atlOffset=-0.17943954;
 		};
 		class Item80
 		{

--- a/maps/cam_lao_nam/mission.sqm
+++ b/maps/cam_lao_nam/mission.sqm
@@ -20,14 +20,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=795;
+		nextID=814;
 	};
 	class Camera
 	{
-		pos[]={14820.604,141.51784,6819.9634};
-		dir[]={-0.46052995,-0.72541845,0.51155251};
-		up[]={-0.48535788,0.68830711,0.53913069};
-		aside[]={0.74320078,4.4834451e-08,0.66907275};
+		pos[]={0,25,-25};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710677,0.70710677};
+		aside[]={0.99999994,0,-0};
 	};
 };
 binarizationWanted=0;
@@ -47,7 +47,6 @@ addons[]=
 	"A3_Characters_F",
 	"characters_f_vietnam_c",
 	"sounds_f_vietnam_c",
-	"cba_jam_vn",
 	"A3_Misc_F_Helpers",
 	"A3_Modules_F"
 };
@@ -55,7 +54,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=16;
+		items=15;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -149,19 +148,12 @@ class AddonsMetaData
 		};
 		class Item13
 		{
-			className="cba_jam_vn";
-			name="Community Base Addons - Joint Ammo Magazines";
-			author="CBA Team";
-			url="https://www.github.com/CBATeam/CBA_A3";
-		};
-		class Item14
-		{
 			className="A3_Misc_F";
 			name="Arma 3 - 3D Aids and Helpers";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item15
+		class Item14
 		{
 			className="A3_Modules_F";
 			name="Arma 3 Alpha - Scripted Modules";
@@ -221,14 +213,14 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="SharedObjectives";
-			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
+			property="ReviveRequiredItems";
+			expression="false";
 			class Value
 			{
 				class data
 				{
 					singleType="SCALAR";
-					value=0;
+					value=2;
 				};
 			};
 		};
@@ -272,14 +264,14 @@ class CustomAttributes
 		};
 		class Attribute4
 		{
-			property="ReviveRequiredItems";
-			expression="false";
+			property="SharedObjectives";
+			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
 			class Value
 			{
 				class data
 				{
 					singleType="SCALAR";
-					value=2;
+					value=0;
 				};
 			};
 		};
@@ -289,19 +281,6 @@ class CustomAttributes
 	{
 		name="Scenario";
 		class Attribute0
-		{
-			property="cba_settings_hasSettingsFile";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					singleType="BOOL";
-					value=1;
-				};
-			};
-		};
-		class Attribute1
 		{
 			property="EnableDebugConsole";
 			expression="true";
@@ -314,7 +293,7 @@ class CustomAttributes
 				};
 			};
 		};
-		nAttributes=2;
+		nAttributes=1;
 	};
 };
 class Mission

--- a/maps/cam_lao_nam/mission.sqm
+++ b/maps/cam_lao_nam/mission.sqm
@@ -6,6 +6,10 @@ class EditorData
 	scaleGridStep=1;
 	autoGroupingDist=10;
 	toggles=521;
+	mods[]=
+	{
+		"3denEnhanced"
+	};
 	class ItemIDProvider
 	{
 		nextID=1606;
@@ -16,18 +20,18 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=776;
+		nextID=795;
 	};
 	class Camera
 	{
-		pos[]={15757.656,72.217995,7047.3052};
-		dir[]={0.17276351,-0.29721525,-0.93909144};
-		up[]={0.053788774,0.9547863,-0.29238018};
-		aside[]={-0.98352438,1.359731e-007,-0.18093935};
+		pos[]={14820.604,141.51784,6819.9634};
+		dir[]={-0.46052995,-0.72541845,0.51155251};
+		up[]={-0.48535788,0.68830711,0.53913069};
+		aside[]={0.74320078,4.4834451e-08,0.66907275};
 	};
 };
 binarizationWanted=0;
-sourceName="vn_mikeforce_indev";
+sourceName="vn_sgd_mikeforce_indev";
 addons[]=
 {
 	"A3_Ui_F",
@@ -202,13 +206,13 @@ class ScenarioData
 		minPlayers=1;
 		maxPlayers=64;
 	};
-	wreckManagerMode=2;
-	wreckLimit=2;
-	wreckRemovalMaxTime=1500;
 	corpseManagerMode=2;
 	corpseLimit=2;
 	corpseRemovalMinTime=10.200001;
 	corpseRemovalMaxTime=1500;
+	wreckManagerMode=2;
+	wreckLimit=2;
+	wreckRemovalMaxTime=1500;
 };
 class CustomAttributes
 {
@@ -217,14 +221,14 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="ReviveRequiredItems";
-			expression="false";
+			property="SharedObjectives";
+			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
 			class Value
 			{
 				class data
 				{
 					singleType="SCALAR";
-					value=2;
+					value=0;
 				};
 			};
 		};
@@ -268,14 +272,14 @@ class CustomAttributes
 		};
 		class Attribute4
 		{
-			property="SharedObjectives";
-			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
+			property="ReviveRequiredItems";
+			expression="false";
 			class Value
 			{
 				class data
 				{
 					singleType="SCALAR";
-					value=0;
+					value=2;
 				};
 			};
 		};
@@ -338,7 +342,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=238;
+		items=234;
 		class Item0
 		{
 			dataType="Marker";
@@ -1560,7 +1564,7 @@ class Mission
 			type="Empty";
 			colorName="ColorOrange";
 			id=316;
-			atlOffset=-1.9073486e-005;
+			atlOffset=-1.9073486e-05;
 		};
 		class Item72
 		{
@@ -1982,7 +1986,7 @@ class Mission
 			type="b_hq";
 			colorName="ColorWEST";
 			id=565;
-			atlOffset=-1.9073486e-005;
+			atlOffset=-1.9073486e-05;
 		};
 		class Item103
 		{
@@ -2121,7 +2125,7 @@ class Mission
 			type="Empty";
 			angle=180.04774;
 			id=666;
-			atlOffset=-1.9073486e-005;
+			atlOffset=-1.9073486e-05;
 		};
 		class Item115
 		{
@@ -2691,7 +2695,7 @@ class Mission
 			};
 			id=727;
 			type="Land_vn_fuel_tank_stairs";
-			atlOffset=-9.5367432e-007;
+			atlOffset=-9.5367432e-07;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -4429,7 +4433,7 @@ class Mission
 			type="mil_arrow";
 			angle=358.57498;
 			id=1057;
-			atlOffset=-16.291449;
+			atlOffset=-23.553333;
 		};
 		class Item163
 		{
@@ -4736,50 +4740,6 @@ class Mission
 		};
 		class Item185
 		{
-			dataType="Marker";
-			position[]={17363.574,49.911869,5588.3711};
-			name="arsenal_acav";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=1120;
-			atlOffset=18.693541;
-		};
-		class Item186
-		{
-			dataType="Marker";
-			position[]={15825.741,14.97998,7108.7227};
-			name="arsenal_greenhornets";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=1121;
-			atlOffset=-1.9073486e-005;
-		};
-		class Item187
-		{
-			dataType="Marker";
-			position[]={16328.838,93.203552,8116.0552};
-			name="arsenal_mikeforce";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=1122;
-			atlOffset=18.69355;
-		};
-		class Item188
-		{
-			dataType="Marker";
-			position[]={14793.342,118.28354,6837.6685};
-			name="arsenal_spiketeam";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=1123;
-			atlOffset=18.693542;
-		};
-		class Item189
-		{
 			dataType="Logic";
 			class PositionInfo
 			{
@@ -4790,7 +4750,7 @@ class Mission
 			id=1124;
 			type="HeadlessClient_F";
 		};
-		class Item190
+		class Item186
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4802,7 +4762,7 @@ class Mission
 			id=1125;
 			type="HeadlessClient_F";
 		};
-		class Item191
+		class Item187
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4814,7 +4774,7 @@ class Mission
 			id=1126;
 			type="HeadlessClient_F";
 		};
-		class Item192
+		class Item188
 		{
 			dataType="Group";
 			side="West";
@@ -5005,7 +4965,7 @@ class Mission
 			};
 			id=1195;
 		};
-		class Item193
+		class Item189
 		{
 			dataType="Group";
 			side="West";
@@ -5196,7 +5156,7 @@ class Mission
 			};
 			id=1197;
 		};
-		class Item194
+		class Item190
 		{
 			dataType="Group";
 			side="West";
@@ -5387,7 +5347,7 @@ class Mission
 			};
 			id=1199;
 		};
-		class Item195
+		class Item191
 		{
 			dataType="Group";
 			side="West";
@@ -5578,7 +5538,7 @@ class Mission
 			};
 			id=1201;
 		};
-		class Item196
+		class Item192
 		{
 			dataType="Group";
 			side="West";
@@ -5769,7 +5729,7 @@ class Mission
 			};
 			id=1203;
 		};
-		class Item197
+		class Item193
 		{
 			dataType="Group";
 			side="West";
@@ -5960,7 +5920,7 @@ class Mission
 			};
 			id=1205;
 		};
-		class Item198
+		class Item194
 		{
 			dataType="Group";
 			side="West";
@@ -6151,7 +6111,7 @@ class Mission
 			};
 			id=1207;
 		};
-		class Item199
+		class Item195
 		{
 			dataType="Group";
 			side="West";
@@ -6342,7 +6302,7 @@ class Mission
 			};
 			id=1209;
 		};
-		class Item200
+		class Item196
 		{
 			dataType="Group";
 			side="West";
@@ -6533,7 +6493,7 @@ class Mission
 			};
 			id=1211;
 		};
-		class Item201
+		class Item197
 		{
 			dataType="Group";
 			side="West";
@@ -6724,7 +6684,7 @@ class Mission
 			};
 			id=1213;
 		};
-		class Item202
+		class Item198
 		{
 			dataType="Group";
 			side="West";
@@ -6917,7 +6877,7 @@ class Mission
 			id=1215;
 			atlOffset=0.028999329;
 		};
-		class Item203
+		class Item199
 		{
 			dataType="Group";
 			side="West";
@@ -7110,7 +7070,7 @@ class Mission
 			id=1217;
 			atlOffset=0.028999329;
 		};
-		class Item204
+		class Item200
 		{
 			dataType="Group";
 			side="West";
@@ -7303,7 +7263,7 @@ class Mission
 			id=1219;
 			atlOffset=0.028999329;
 		};
-		class Item205
+		class Item201
 		{
 			dataType="Group";
 			side="West";
@@ -7496,7 +7456,7 @@ class Mission
 			id=1221;
 			atlOffset=0.028999329;
 		};
-		class Item206
+		class Item202
 		{
 			dataType="Group";
 			side="West";
@@ -7689,7 +7649,7 @@ class Mission
 			id=1223;
 			atlOffset=0.028999329;
 		};
-		class Item207
+		class Item203
 		{
 			dataType="Group";
 			side="West";
@@ -7880,7 +7840,7 @@ class Mission
 			};
 			id=1225;
 		};
-		class Item208
+		class Item204
 		{
 			dataType="Group";
 			side="West";
@@ -8071,7 +8031,7 @@ class Mission
 			};
 			id=1227;
 		};
-		class Item209
+		class Item205
 		{
 			dataType="Group";
 			side="West";
@@ -8262,7 +8222,7 @@ class Mission
 			};
 			id=1229;
 		};
-		class Item210
+		class Item206
 		{
 			dataType="Group";
 			side="West";
@@ -8453,7 +8413,7 @@ class Mission
 			};
 			id=1231;
 		};
-		class Item211
+		class Item207
 		{
 			dataType="Group";
 			side="West";
@@ -8644,7 +8604,7 @@ class Mission
 			};
 			id=1233;
 		};
-		class Item212
+		class Item208
 		{
 			dataType="Group";
 			side="West";
@@ -8835,7 +8795,7 @@ class Mission
 			};
 			id=1235;
 		};
-		class Item213
+		class Item209
 		{
 			dataType="Group";
 			side="West";
@@ -9026,7 +8986,7 @@ class Mission
 			};
 			id=1237;
 		};
-		class Item214
+		class Item210
 		{
 			dataType="Group";
 			side="West";
@@ -9217,7 +9177,7 @@ class Mission
 			};
 			id=1239;
 		};
-		class Item215
+		class Item211
 		{
 			dataType="Group";
 			side="West";
@@ -9408,7 +9368,7 @@ class Mission
 			};
 			id=1241;
 		};
-		class Item216
+		class Item212
 		{
 			dataType="Group";
 			side="West";
@@ -9599,7 +9559,7 @@ class Mission
 			};
 			id=1243;
 		};
-		class Item217
+		class Item213
 		{
 			dataType="Group";
 			side="West";
@@ -9790,7 +9750,7 @@ class Mission
 			};
 			id=1245;
 		};
-		class Item218
+		class Item214
 		{
 			dataType="Group";
 			side="West";
@@ -9981,7 +9941,7 @@ class Mission
 			};
 			id=1247;
 		};
-		class Item219
+		class Item215
 		{
 			dataType="Group";
 			side="West";
@@ -10172,7 +10132,7 @@ class Mission
 			};
 			id=1249;
 		};
-		class Item220
+		class Item216
 		{
 			dataType="Group";
 			side="West";
@@ -10363,7 +10323,7 @@ class Mission
 			};
 			id=1251;
 		};
-		class Item221
+		class Item217
 		{
 			dataType="Group";
 			side="West";
@@ -10554,7 +10514,7 @@ class Mission
 			};
 			id=1253;
 		};
-		class Item222
+		class Item218
 		{
 			dataType="Group";
 			side="West";
@@ -10745,7 +10705,7 @@ class Mission
 			};
 			id=1275;
 		};
-		class Item223
+		class Item219
 		{
 			dataType="Group";
 			side="West";
@@ -10936,7 +10896,7 @@ class Mission
 			};
 			id=1277;
 		};
-		class Item224
+		class Item220
 		{
 			dataType="Group";
 			side="West";
@@ -11127,7 +11087,7 @@ class Mission
 			};
 			id=1279;
 		};
-		class Item225
+		class Item221
 		{
 			dataType="Group";
 			side="West";
@@ -11318,7 +11278,7 @@ class Mission
 			};
 			id=1281;
 		};
-		class Item226
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11335,7 +11295,7 @@ class Mission
 			id=1291;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item227
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11352,7 +11312,7 @@ class Mission
 			id=1292;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item228
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11369,7 +11329,7 @@ class Mission
 			id=1293;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item229
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11386,9 +11346,9 @@ class Mission
 			};
 			id=1294;
 			type="Land_vn_object_trashcan_01";
-			atlOffset=1.1444092e-005;
+			atlOffset=1.1444092e-05;
 		};
-		class Item230
+		class Item226
 		{
 			dataType="Layer";
 			name="Vehicle spawn point";
@@ -11418,7 +11378,7 @@ class Mission
 							};
 							id=1322;
 							type="vn_signad_sponsors_f";
-							atlOffset=2.2888184e-005;
+							atlOffset=2.2888184e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -11481,7 +11441,7 @@ class Mission
 							};
 							id=1343;
 							type="vn_signad_sponsors_f";
-							atlOffset=2.2888184e-005;
+							atlOffset=2.2888184e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -11679,7 +11639,7 @@ class Mission
 							};
 							id=1355;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -11725,7 +11685,7 @@ class Mission
 							init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1357;
 							type="Logic";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 						};
 						class Item3
 						{
@@ -11743,7 +11703,7 @@ class Mission
 							};
 							id=1362;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -11789,7 +11749,7 @@ class Mission
 							init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1364;
 							type="Logic";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 						};
 						class Item6
 						{
@@ -11807,7 +11767,7 @@ class Mission
 							};
 							id=1365;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -11853,7 +11813,7 @@ class Mission
 							init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1367;
 							type="Logic";
-							atlOffset=1.5258789e-005;
+							atlOffset=1.5258789e-05;
 						};
 					};
 					id=1368;
@@ -13685,7 +13645,7 @@ class Mission
 							class PositionInfo
 							{
 								position[]={15770.414,16.121468,7028.2046};
-								angles[]={0,4.8158174,-0};
+								angles[]={0,4.8158174,0};
 							};
 							side="Empty";
 							flags=5;
@@ -13719,7 +13679,7 @@ class Mission
 							class PositionInfo
 							{
 								position[]={15756.339,14.98,7036.8936};
-								angles[]={-0,5.7423425,0};
+								angles[]={0,5.7423425,0};
 							};
 							init="['c119_unarmed', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1600;
@@ -13747,7 +13707,7 @@ class Mission
 							class PositionInfo
 							{
 								position[]={15943.627,16.121468,6891.2007};
-								angles[]={0,3.1385608,-0};
+								angles[]={0,3.1385608,0};
 							};
 							side="Empty";
 							flags=5;
@@ -13781,7 +13741,7 @@ class Mission
 							class PositionInfo
 							{
 								position[]={15959.27,14.98,6879.9424};
-								angles[]={-0,5.7423425,0};
+								angles[]={0,5.7423425,0};
 							};
 							init="['c119_armed', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1603;
@@ -13805,7 +13765,7 @@ class Mission
 						};
 					};
 					id=1397;
-					atlOffset=0.57143211;
+					atlOffset=0.5714283;
 				};
 				class Item9
 				{
@@ -14022,7 +13982,7 @@ class Mission
 							init="['heavy_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1485;
 							type="Logic";
-							atlOffset=1.335144e-005;
+							atlOffset=1.335144e-05;
 						};
 						class Item1
 						{
@@ -14040,7 +14000,7 @@ class Mission
 							};
 							id=1486;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.1444092e-005;
+							atlOffset=1.1444092e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -14086,7 +14046,7 @@ class Mission
 							init="['heavy_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1488;
 							type="Logic";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 						};
 						class Item4
 						{
@@ -14104,7 +14064,7 @@ class Mission
 							};
 							id=1489;
 							type="vn_signad_sponsors_f";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -14285,7 +14245,7 @@ class Mission
 							init="['transport_heavy', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1473;
 							type="Logic";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 						};
 						class Item7
 						{
@@ -14410,7 +14370,7 @@ class Mission
 							init="['transport_heavy', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1482;
 							type="Logic";
-							atlOffset=3.8146973e-006;
+							atlOffset=3.8146973e-06;
 						};
 						class Item13
 						{
@@ -14428,7 +14388,7 @@ class Mission
 							};
 							id=1483;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.9073486e-006;
+							atlOffset=1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -14485,7 +14445,7 @@ class Mission
 							init="['light_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1491;
 							type="Logic";
-							atlOffset=1.335144e-005;
+							atlOffset=1.335144e-05;
 						};
 						class Item1
 						{
@@ -14503,7 +14463,7 @@ class Mission
 							};
 							id=1492;
 							type="vn_signad_sponsors_f";
-							atlOffset=9.5367432e-006;
+							atlOffset=9.5367432e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -14611,7 +14571,7 @@ class Mission
 							init="['light_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1498;
 							type="Logic";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 						};
 						class Item7
 						{
@@ -14629,7 +14589,7 @@ class Mission
 							};
 							id=1499;
 							type="vn_signad_sponsors_f";
-							atlOffset=-1.9073486e-006;
+							atlOffset=-1.9073486e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -14675,7 +14635,7 @@ class Mission
 							init="['light_fire_support', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=1501;
 							type="Logic";
-							atlOffset=1.335144e-005;
+							atlOffset=1.335144e-05;
 						};
 						class Item10
 						{
@@ -14693,7 +14653,7 @@ class Mission
 							};
 							id=1502;
 							type="vn_signad_sponsors_f";
-							atlOffset=1.1444092e-005;
+							atlOffset=1.1444092e-05;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -14734,9 +14694,9 @@ class Mission
 				};
 			};
 			id=1325;
-			atlOffset=-0.58335304;
+			atlOffset=-0.59669876;
 		};
-		class Item231
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14751,7 +14711,7 @@ class Mission
 			id=629;
 			type="Land_vn_helipadcircle_f";
 		};
-		class Item232
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14766,7 +14726,7 @@ class Mission
 			id=1416;
 			type="Land_vn_helipadcircle_f";
 		};
-		class Item233
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14781,7 +14741,7 @@ class Mission
 			id=1417;
 			type="Land_vn_helipadcircle_f";
 		};
-		class Item234
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14796,7 +14756,7 @@ class Mission
 			id=1418;
 			type="Land_vn_helipadcircle_f";
 		};
-		class Item235
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14831,7 +14791,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item236
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14866,7 +14826,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item237
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo

--- a/maps/vn_khe_sanh/mission.sqm
+++ b/maps/vn_khe_sanh/mission.sqm
@@ -6,6 +6,10 @@ class EditorData
 	scaleGridStep=1;
 	autoGroupingDist=10;
 	toggles=513;
+	mods[]=
+	{
+		"3denEnhanced"
+	};
 	class ItemIDProvider
 	{
 		nextID=660;
@@ -16,18 +20,18 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=551;
+		nextID=588;
 	};
 	class Camera
 	{
-		pos[]={10738.874,115.86653,3145.75};
-		dir[]={0.81315744,-0.45815358,-0.35903051};
-		up[]={0.41912553,0.88886583,-0.18505408};
-		aside[]={-0.4039135,-4.3219188e-009,-0.91481405};
+		pos[]={10813.433,111.94389,3010.2258};
+		dir[]={0.049677726,-0.49494424,0.86750495};
+		up[]={0.028296668,0.8689239,0.49413493};
+		aside[]={0.99836475,3.7616701e-09,-0.057171442};
 	};
 };
 binarizationWanted=0;
-sourceName="vn_mikeforce_indev";
+sourceName="vn_sgd_mikeforce_indev";
 addons[]=
 {
 	"A3_Ui_F",
@@ -45,13 +49,14 @@ addons[]=
 	"A3_Structures_F_Items_Tools",
 	"characters_f_vietnam_c",
 	"sounds_f_vietnam_c",
+	"cba_jam_vn",
 	"A3_Misc_F_Helpers"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=16;
+		items=17;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -159,6 +164,13 @@ class AddonsMetaData
 		};
 		class Item15
 		{
+			className="cba_jam_vn";
+			name="Community Base Addons - Joint Ammo Magazines";
+			author="CBA Team";
+			url="https://www.github.com/CBATeam/CBA_A3";
+		};
+		class Item16
+		{
 			className="A3_Misc_F";
 			name="Arma 3 - 3D Aids and Helpers";
 			author="Bohemia Interactive";
@@ -198,12 +210,12 @@ class ScenarioData
 		minPlayers=1;
 		maxPlayers=30;
 	};
-	wreckManagerMode=2;
-	wreckLimit=2;
-	wreckRemovalMaxTime=1500;
 	corpseManagerMode=2;
 	corpseLimit=2;
 	corpseRemovalMaxTime=1500;
+	wreckManagerMode=2;
+	wreckLimit=2;
+	wreckRemovalMaxTime=1500;
 };
 class CustomAttributes
 {
@@ -219,6 +231,24 @@ class CustomAttributes
 				class data
 				{
 					singleType="ARRAY";
+				};
+			};
+		};
+		nAttributes=1;
+	};
+	class Category1
+	{
+		name="Scenario";
+		class Attribute0
+		{
+			property="cba_settings_hasSettingsFile";
+			expression="false";
+			class Value
+			{
+				class data
+				{
+					singleType="BOOL";
+					value=1;
 				};
 			};
 		};
@@ -251,7 +281,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=92;
+		items=88;
 		class Item0
 		{
 			dataType="Layer";
@@ -691,7 +721,7 @@ class Mission
 					};
 					id=33;
 					type="EmptyDetectorAreaR250";
-					atlOffset=-1.5258789e-005;
+					atlOffset=-1.5258789e-05;
 				};
 				class Item1
 				{
@@ -778,7 +808,7 @@ class Mission
 					};
 					id=26;
 					type="EmptyDetectorAreaR250";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 				};
 				class Item8
 				{
@@ -1517,7 +1547,7 @@ class Mission
 					};
 					id=76;
 					type="Land_SatelliteAntenna_01_F";
-					atlOffset=10.816376;
+					atlOffset=10.896271;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -1538,7 +1568,7 @@ class Mission
 				};
 			};
 			id=124;
-			atlOffset=10.816376;
+			atlOffset=10.896271;
 		};
 		class Item15
 		{
@@ -1987,45 +2017,12 @@ class Mission
 		};
 		class Item16
 		{
-			dataType="Marker";
-			position[]={10602.249,117.134,3202.8579};
-			name="arsenal";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=126;
-			atlOffset=18.693245;
-		};
-		class Item17
-		{
-			dataType="Marker";
-			position[]={10656.013,117.26701,3125.9373};
-			name="arsenal_1";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=128;
-			atlOffset=18.757011;
-		};
-		class Item18
-		{
-			dataType="Marker";
-			position[]={10813.897,116.787,3188.1321};
-			name="arsenal_2";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=129;
-			atlOffset=18.713417;
-		};
-		class Item19
-		{
 			dataType="Layer";
 			name="Players";
 			id=193;
 			atlOffset=-36.689999;
 		};
-		class Item20
+		class Item17
 		{
 			dataType="Layer";
 			name="Arsenals";
@@ -2174,7 +2171,7 @@ class Mission
 			id=196;
 			atlOffset=-0.10418701;
 		};
-		class Item21
+		class Item18
 		{
 			dataType="Marker";
 			position[]={10655.866,98.510002,3128.2068};
@@ -2185,7 +2182,7 @@ class Mission
 			angle=92.983536;
 			id=197;
 		};
-		class Item22
+		class Item19
 		{
 			dataType="Marker";
 			position[]={10604.54,98.44249,3203.677};
@@ -2196,7 +2193,7 @@ class Mission
 			angle=230.6922;
 			id=199;
 		};
-		class Item23
+		class Item20
 		{
 			dataType="Marker";
 			position[]={10823.463,98.459999,3187.8701};
@@ -2208,7 +2205,7 @@ class Mission
 			id=200;
 			atlOffset=0.00043487549;
 		};
-		class Item24
+		class Item21
 		{
 			dataType="Marker";
 			position[]={10955.847,94.763916,2800.3469};
@@ -2222,7 +2219,7 @@ class Mission
 			id=201;
 			atlOffset=-1.7060852;
 		};
-		class Item25
+		class Item22
 		{
 			dataType="Marker";
 			position[]={10667.141,98.378448,3124.1934};
@@ -2232,7 +2229,7 @@ class Mission
 			id=203;
 			atlOffset=-0.085868835;
 		};
-		class Item26
+		class Item23
 		{
 			dataType="Marker";
 			position[]={10813.69,98.557999,3141.7671};
@@ -2241,9 +2238,9 @@ class Mission
 			type="Empty";
 			angle=39.819992;
 			id=204;
-			atlOffset=-4.5776367e-005;
+			atlOffset=-4.5776367e-05;
 		};
-		class Item27
+		class Item24
 		{
 			dataType="Marker";
 			position[]={10704.667,91.056641,3111.8169};
@@ -2253,7 +2250,7 @@ class Mission
 			id=205;
 			atlOffset=-7.3433609;
 		};
-		class Item28
+		class Item25
 		{
 			dataType="Marker";
 			position[]={10602.046,80.530273,3199.5322};
@@ -2263,7 +2260,7 @@ class Mission
 			id=206;
 			atlOffset=-17.943504;
 		};
-		class Item29
+		class Item26
 		{
 			dataType="Marker";
 			position[]={11002.336,97.840088,3158.8003};
@@ -2273,7 +2270,7 @@ class Mission
 			id=207;
 			atlOffset=-0.63991547;
 		};
-		class Item30
+		class Item27
 		{
 			dataType="Marker";
 			position[]={10705.053,87.361328,3134.2622};
@@ -2283,7 +2280,7 @@ class Mission
 			id=208;
 			atlOffset=-11.038673;
 		};
-		class Item31
+		class Item28
 		{
 			dataType="Marker";
 			position[]={10954.471,83.799561,2800.5195};
@@ -2293,7 +2290,7 @@ class Mission
 			id=209;
 			atlOffset=-12.670418;
 		};
-		class Item32
+		class Item29
 		{
 			dataType="Marker";
 			position[]={10979.415,98.480003,3058.7063};
@@ -2302,7 +2299,7 @@ class Mission
 			type="b_air";
 			id=210;
 		};
-		class Item33
+		class Item30
 		{
 			dataType="Marker";
 			position[]={11006.622,98.480003,3158.2861};
@@ -2313,7 +2310,7 @@ class Mission
 			angle=287.36862;
 			id=198;
 		};
-		class Item34
+		class Item31
 		{
 			dataType="Marker";
 			position[]={10929.51,99.368477,3180.8333};
@@ -2324,7 +2321,7 @@ class Mission
 			id=216;
 			atlOffset=0.88847351;
 		};
-		class Item35
+		class Item32
 		{
 			dataType="Marker";
 			position[]={10943.689,98.480003,3174.5701};
@@ -2334,7 +2331,7 @@ class Mission
 			colorName="ColorOrange";
 			id=217;
 		};
-		class Item36
+		class Item33
 		{
 			dataType="Layer";
 			name="Rearm Points";
@@ -2357,7 +2354,7 @@ class Mission
 					};
 					id=225;
 					type="Land_vn_usaf_fueltank_75_01";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2495,7 +2492,7 @@ class Mission
 					};
 					id=245;
 					type="Land_vn_usaf_fueltank_75_01";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2774,7 +2771,7 @@ class Mission
 					};
 					id=332;
 					type="Land_vn_usaf_fueltank_75_01";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2809,7 +2806,7 @@ class Mission
 					};
 					id=333;
 					type="Land_vn_usaf_fueltank_75_01";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2832,14 +2829,14 @@ class Mission
 			id=224;
 			atlOffset=0.90512085;
 		};
-		class Item37
+		class Item34
 		{
 			dataType="Layer";
 			name="Vehicles_1";
 			id=251;
 			atlOffset=-36.689999;
 		};
-		class Item38
+		class Item35
 		{
 			dataType="Layer";
 			name="Wreck Bay";
@@ -3516,7 +3513,7 @@ class Mission
 			id=331;
 			atlOffset=-0.12821198;
 		};
-		class Item39
+		class Item36
 		{
 			dataType="Marker";
 			position[]={10695.389,41.604774,3165.2441};
@@ -3529,7 +3526,7 @@ class Mission
 			id=344;
 			atlOffset=-56.997299;
 		};
-		class Item40
+		class Item37
 		{
 			dataType="Marker";
 			position[]={10986.035,75.810997,3136.8379};
@@ -3542,7 +3539,7 @@ class Mission
 			id=345;
 			atlOffset=-22.669006;
 		};
-		class Item41
+		class Item38
 		{
 			dataType="Group";
 			side="West";
@@ -3734,7 +3731,7 @@ class Mission
 			};
 			id=414;
 		};
-		class Item42
+		class Item39
 		{
 			dataType="Group";
 			side="West";
@@ -3926,7 +3923,7 @@ class Mission
 			};
 			id=416;
 		};
-		class Item43
+		class Item40
 		{
 			dataType="Group";
 			side="West";
@@ -4118,7 +4115,7 @@ class Mission
 			};
 			id=418;
 		};
-		class Item44
+		class Item41
 		{
 			dataType="Group";
 			side="West";
@@ -4310,7 +4307,7 @@ class Mission
 			};
 			id=420;
 		};
-		class Item45
+		class Item42
 		{
 			dataType="Group";
 			side="West";
@@ -4502,7 +4499,7 @@ class Mission
 			};
 			id=422;
 		};
-		class Item46
+		class Item43
 		{
 			dataType="Group";
 			side="West";
@@ -4694,7 +4691,7 @@ class Mission
 			};
 			id=424;
 		};
-		class Item47
+		class Item44
 		{
 			dataType="Group";
 			side="West";
@@ -4886,7 +4883,7 @@ class Mission
 			};
 			id=426;
 		};
-		class Item48
+		class Item45
 		{
 			dataType="Group";
 			side="West";
@@ -5078,7 +5075,7 @@ class Mission
 			};
 			id=428;
 		};
-		class Item49
+		class Item46
 		{
 			dataType="Group";
 			side="West";
@@ -5270,7 +5267,7 @@ class Mission
 			};
 			id=430;
 		};
-		class Item50
+		class Item47
 		{
 			dataType="Group";
 			side="West";
@@ -5462,7 +5459,7 @@ class Mission
 			};
 			id=432;
 		};
-		class Item51
+		class Item48
 		{
 			dataType="Group";
 			side="West";
@@ -5654,7 +5651,7 @@ class Mission
 			};
 			id=434;
 		};
-		class Item52
+		class Item49
 		{
 			dataType="Group";
 			side="West";
@@ -5846,7 +5843,7 @@ class Mission
 			};
 			id=436;
 		};
-		class Item53
+		class Item50
 		{
 			dataType="Group";
 			side="West";
@@ -6001,7 +5998,7 @@ class Mission
 					};
 					id=439;
 					type="vn_b_men_sf_06";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6038,9 +6035,9 @@ class Mission
 			{
 			};
 			id=438;
-			atlOffset=7.6293945e-006;
+			atlOffset=7.6293945e-06;
 		};
-		class Item54
+		class Item51
 		{
 			dataType="Group";
 			side="West";
@@ -6195,7 +6192,7 @@ class Mission
 					};
 					id=441;
 					type="vn_b_men_sf_06";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6232,9 +6229,9 @@ class Mission
 			{
 			};
 			id=440;
-			atlOffset=7.6293945e-006;
+			atlOffset=7.6293945e-06;
 		};
-		class Item55
+		class Item52
 		{
 			dataType="Group";
 			side="West";
@@ -6426,7 +6423,7 @@ class Mission
 			};
 			id=442;
 		};
-		class Item56
+		class Item53
 		{
 			dataType="Group";
 			side="West";
@@ -6581,7 +6578,7 @@ class Mission
 					};
 					id=445;
 					type="vn_b_men_sf_06";
-					atlOffset=-7.6293945e-006;
+					atlOffset=-7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6618,9 +6615,9 @@ class Mission
 			{
 			};
 			id=444;
-			atlOffset=-7.6293945e-006;
+			atlOffset=-7.6293945e-06;
 		};
-		class Item57
+		class Item54
 		{
 			dataType="Group";
 			side="West";
@@ -6775,7 +6772,7 @@ class Mission
 					};
 					id=447;
 					type="vn_b_men_sf_06";
-					atlOffset=-7.6293945e-006;
+					atlOffset=-7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -6812,9 +6809,9 @@ class Mission
 			{
 			};
 			id=446;
-			atlOffset=-7.6293945e-006;
+			atlOffset=-7.6293945e-06;
 		};
-		class Item58
+		class Item55
 		{
 			dataType="Group";
 			side="West";
@@ -7006,7 +7003,7 @@ class Mission
 			};
 			id=448;
 		};
-		class Item59
+		class Item56
 		{
 			dataType="Group";
 			side="West";
@@ -7198,7 +7195,7 @@ class Mission
 			};
 			id=450;
 		};
-		class Item60
+		class Item57
 		{
 			dataType="Group";
 			side="West";
@@ -7353,7 +7350,7 @@ class Mission
 					};
 					id=453;
 					type="vn_b_men_sf_06";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7390,9 +7387,9 @@ class Mission
 			{
 			};
 			id=452;
-			atlOffset=7.6293945e-006;
+			atlOffset=7.6293945e-06;
 		};
-		class Item61
+		class Item58
 		{
 			dataType="Group";
 			side="West";
@@ -7584,7 +7581,7 @@ class Mission
 			};
 			id=454;
 		};
-		class Item62
+		class Item59
 		{
 			dataType="Group";
 			side="West";
@@ -7776,7 +7773,7 @@ class Mission
 			};
 			id=456;
 		};
-		class Item63
+		class Item60
 		{
 			dataType="Group";
 			side="West";
@@ -7968,7 +7965,7 @@ class Mission
 			};
 			id=458;
 		};
-		class Item64
+		class Item61
 		{
 			dataType="Group";
 			side="West";
@@ -8160,7 +8157,7 @@ class Mission
 			};
 			id=460;
 		};
-		class Item65
+		class Item62
 		{
 			dataType="Group";
 			side="West";
@@ -8352,7 +8349,7 @@ class Mission
 			};
 			id=462;
 		};
-		class Item66
+		class Item63
 		{
 			dataType="Group";
 			side="West";
@@ -8544,7 +8541,7 @@ class Mission
 			};
 			id=464;
 		};
-		class Item67
+		class Item64
 		{
 			dataType="Group";
 			side="West";
@@ -8699,7 +8696,7 @@ class Mission
 					};
 					id=467;
 					type="vn_b_men_sf_06";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -8736,9 +8733,9 @@ class Mission
 			{
 			};
 			id=466;
-			atlOffset=7.6293945e-006;
+			atlOffset=7.6293945e-06;
 		};
-		class Item68
+		class Item65
 		{
 			dataType="Group";
 			side="West";
@@ -8930,7 +8927,7 @@ class Mission
 			};
 			id=468;
 		};
-		class Item69
+		class Item66
 		{
 			dataType="Group";
 			side="West";
@@ -9122,7 +9119,7 @@ class Mission
 			};
 			id=470;
 		};
-		class Item70
+		class Item67
 		{
 			dataType="Group";
 			side="West";
@@ -9277,7 +9274,7 @@ class Mission
 					};
 					id=473;
 					type="vn_b_men_sf_06";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -9314,9 +9311,9 @@ class Mission
 			{
 			};
 			id=472;
-			atlOffset=7.6293945e-006;
+			atlOffset=7.6293945e-06;
 		};
-		class Item71
+		class Item68
 		{
 			dataType="Group";
 			side="West";
@@ -9508,7 +9505,7 @@ class Mission
 			};
 			id=474;
 		};
-		class Item72
+		class Item69
 		{
 			dataType="Group";
 			side="West";
@@ -9700,7 +9697,7 @@ class Mission
 			};
 			id=476;
 		};
-		class Item73
+		class Item70
 		{
 			dataType="Group";
 			side="West";
@@ -9892,7 +9889,7 @@ class Mission
 			};
 			id=478;
 		};
-		class Item74
+		class Item71
 		{
 			dataType="Group";
 			side="West";
@@ -10085,7 +10082,7 @@ class Mission
 			};
 			id=486;
 		};
-		class Item75
+		class Item72
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10103,7 +10100,7 @@ class Mission
 			id=503;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item76
+		class Item73
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10120,9 +10117,9 @@ class Mission
 			};
 			id=504;
 			type="Land_vn_object_trashcan_01";
-			atlOffset=7.6293945e-006;
+			atlOffset=7.6293945e-06;
 		};
-		class Item77
+		class Item74
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10140,7 +10137,7 @@ class Mission
 			id=505;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item78
+		class Item75
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10158,18 +10155,7 @@ class Mission
 			id=508;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item79
-		{
-			dataType="Marker";
-			position[]={11006.641,117.19342,3162.2783};
-			name="arsenal_3";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=509;
-			atlOffset=18.713417;
-		};
-		class Item80
+		class Item76
 		{
 			dataType="Layer";
 			name="Air support #1";
@@ -10243,7 +10229,7 @@ class Mission
 			id=561;
 			atlOffset=0.22589111;
 		};
-		class Item81
+		class Item77
 		{
 			dataType="Layer";
 			name="Heavy air support #1";
@@ -10317,7 +10303,7 @@ class Mission
 			id=568;
 			atlOffset=0.22264099;
 		};
-		class Item82
+		class Item78
 		{
 			dataType="Layer";
 			name="Jet spawn #1";
@@ -10465,7 +10451,7 @@ class Mission
 			id=572;
 			atlOffset=0.12874603;
 		};
-		class Item83
+		class Item79
 		{
 			dataType="Layer";
 			name="Light transport spawns";
@@ -10613,7 +10599,7 @@ class Mission
 							init="['light_transport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=601;
 							type="Logic";
-							atlOffset=-7.6293945e-006;
+							atlOffset=-7.6293945e-06;
 						};
 					};
 					id=598;
@@ -10760,7 +10746,7 @@ class Mission
 							init="['light_transport', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=608;
 							type="Logic";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 						};
 					};
 					id=609;
@@ -10770,7 +10756,7 @@ class Mission
 			id=582;
 			atlOffset=0.28301239;
 		};
-		class Item84
+		class Item80
 		{
 			dataType="Layer";
 			name="Light air spawns";
@@ -11076,7 +11062,7 @@ class Mission
 			id=583;
 			atlOffset=6.735405;
 		};
-		class Item85
+		class Item81
 		{
 			dataType="Layer";
 			name="Air transport spawns";
@@ -11235,7 +11221,7 @@ class Mission
 			id=584;
 			atlOffset=0.28773499;
 		};
-		class Item86
+		class Item82
 		{
 			dataType="Layer";
 			name="Patrol spawns";
@@ -11354,7 +11340,7 @@ class Mission
 							};
 							id=588;
 							type="vn_signad_sponsors_f";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -11457,7 +11443,7 @@ class Mission
 							init="['patrol', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=592;
 							type="Logic";
-							atlOffset=7.6293945e-006;
+							atlOffset=7.6293945e-06;
 						};
 					};
 					id=593;
@@ -11540,7 +11526,7 @@ class Mission
 			id=585;
 			atlOffset=0.15614319;
 		};
-		class Item87
+		class Item83
 		{
 			dataType="Layer";
 			name="Heavy transport spawns";
@@ -11675,7 +11661,7 @@ class Mission
 			id=623;
 			atlOffset=0.15859222;
 		};
-		class Item88
+		class Item84
 		{
 			dataType="Layer";
 			name="Truck spawns";
@@ -11810,7 +11796,7 @@ class Mission
 			id=610;
 			atlOffset=0.14334106;
 		};
-		class Item89
+		class Item85
 		{
 			dataType="Layer";
 			name="Utility spawns";
@@ -11833,7 +11819,7 @@ class Mission
 					};
 					id=626;
 					type="vn_signad_sponsors_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -11863,7 +11849,7 @@ class Mission
 					init="['utility', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 					id=627;
 					type="Logic";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 				};
 				class Item2
 				{
@@ -12009,7 +11995,7 @@ class Mission
 			id=624;
 			atlOffset=0.56558228;
 		};
-		class Item90
+		class Item86
 		{
 			dataType="Layer";
 			name="Heavy fire support spawns";
@@ -12083,7 +12069,7 @@ class Mission
 			id=648;
 			atlOffset=0.26174927;
 		};
-		class Item91
+		class Item87
 		{
 			dataType="Layer";
 			name="Light fire support spawns";
@@ -12122,7 +12108,7 @@ class Mission
 					};
 					id=656;
 					type="vn_signad_sponsors_f";
-					atlOffset=7.6293945e-006;
+					atlOffset=7.6293945e-06;
 					class CustomAttributes
 					{
 						class Attribute0

--- a/maps/vn_khe_sanh/mission.sqm
+++ b/maps/vn_khe_sanh/mission.sqm
@@ -20,14 +20,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=588;
+		nextID=625;
 	};
 	class Camera
 	{
-		pos[]={10813.433,111.94389,3010.2258};
-		dir[]={0.049677726,-0.49494424,0.86750495};
-		up[]={0.028296668,0.8689239,0.49413493};
-		aside[]={0.99836475,3.7616701e-09,-0.057171442};
+		pos[]={0,31.920967,-25};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710677,0.70710677};
+		aside[]={0.99999994,0,-0};
 	};
 };
 binarizationWanted=0;
@@ -49,14 +49,13 @@ addons[]=
 	"A3_Structures_F_Items_Tools",
 	"characters_f_vietnam_c",
 	"sounds_f_vietnam_c",
-	"cba_jam_vn",
 	"A3_Misc_F_Helpers"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=17;
+		items=16;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -164,13 +163,6 @@ class AddonsMetaData
 		};
 		class Item15
 		{
-			className="cba_jam_vn";
-			name="Community Base Addons - Joint Ammo Magazines";
-			author="CBA Team";
-			url="https://www.github.com/CBATeam/CBA_A3";
-		};
-		class Item16
-		{
 			className="A3_Misc_F";
 			name="Arma 3 - 3D Aids and Helpers";
 			author="Bohemia Interactive";
@@ -231,24 +223,6 @@ class CustomAttributes
 				class data
 				{
 					singleType="ARRAY";
-				};
-			};
-		};
-		nAttributes=1;
-	};
-	class Category1
-	{
-		name="Scenario";
-		class Attribute0
-		{
-			property="cba_settings_hasSettingsFile";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					singleType="BOOL";
-					value=1;
 				};
 			};
 		};
@@ -1547,7 +1521,7 @@ class Mission
 					};
 					id=76;
 					type="Land_SatelliteAntenna_01_F";
-					atlOffset=10.896271;
+					atlOffset=10.816376;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -1568,7 +1542,7 @@ class Mission
 				};
 			};
 			id=124;
-			atlOffset=10.896271;
+			atlOffset=10.816376;
 		};
 		class Item15
 		{

--- a/maps/vn_the_bra/mission.sqm
+++ b/maps/vn_the_bra/mission.sqm
@@ -6,6 +6,10 @@ class EditorData
 	scaleGridStep=1;
 	autoGroupingDist=10;
 	toggles=1537;
+	mods[]=
+	{
+		"3denEnhanced"
+	};
 	class ItemIDProvider
 	{
 		nextID=639;
@@ -16,18 +20,18 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=684;
+		nextID=713;
 	};
 	class Camera
 	{
-		pos[]={3522.6306,85.464821,4409.623};
-		dir[]={0.9603883,-0.27665213,-0.034191575};
-		up[]={0.27649489,0.960967,-0.0098444363};
-		aside[]={-0.0355797,3.3799734e-007,-0.99939507};
+		pos[]={3482.189,125.19694,4428.1924};
+		dir[]={0.77116805,-0.3905654,-0.50280321};
+		up[]={0.32717898,0.92057109,-0.21332233};
+		aside[]={-0.54618192,3.3559627e-07,-0.83770043};
 	};
 };
 binarizationWanted=0;
-sourceName="vn_mikeforce_indev";
+sourceName="vn_sgd_mikeforce_indev";
 addons[]=
 {
 	"modules_f_vietnam",
@@ -42,6 +46,7 @@ addons[]=
 	"A3_Structures_F_Items_Tools",
 	"characters_f_vietnam_c",
 	"sounds_f_vietnam_c",
+	"cba_jam_vn",
 	"A3_Misc_F_Helpers",
 	"A3_Modules_F"
 };
@@ -49,7 +54,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=14;
+		items=15;
 		class Item0
 		{
 			className="modules_f_vietnam";
@@ -136,12 +141,19 @@ class AddonsMetaData
 		};
 		class Item12
 		{
+			className="cba_jam_vn";
+			name="Community Base Addons - Joint Ammo Magazines";
+			author="CBA Team";
+			url="https://www.github.com/CBATeam/CBA_A3";
+		};
+		class Item13
+		{
 			className="A3_Misc_F";
 			name="Arma 3 - 3D Aids and Helpers";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item13
+		class Item14
 		{
 			className="A3_Modules_F";
 			name="Arma 3 Alpha - Scripted Modules";
@@ -181,12 +193,12 @@ class ScenarioData
 		minPlayers=1;
 		maxPlayers=30;
 	};
-	wreckManagerMode=2;
-	wreckLimit=2;
-	wreckRemovalMaxTime=1500;
 	corpseManagerMode=2;
 	corpseLimit=2;
 	corpseRemovalMaxTime=1500;
+	wreckManagerMode=2;
+	wreckLimit=2;
+	wreckRemovalMaxTime=1500;
 };
 class CustomAttributes
 {
@@ -202,6 +214,24 @@ class CustomAttributes
 				class data
 				{
 					singleType="ARRAY";
+				};
+			};
+		};
+		nAttributes=1;
+	};
+	class Category1
+	{
+		name="Scenario";
+		class Attribute0
+		{
+			property="cba_settings_hasSettingsFile";
+			expression="false";
+			class Value
+			{
+				class data
+				{
+					singleType="BOOL";
+					value=1;
 				};
 			};
 		};
@@ -232,7 +262,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=93;
+		items=91;
 		class Item0
 		{
 			dataType="Layer";
@@ -1407,7 +1437,7 @@ class Mission
 			};
 			id=123;
 			type="vn_module_whitelistedarsenal";
-			atlOffset=-3.8146973e-006;
+			atlOffset=-3.8146973e-06;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -1737,34 +1767,12 @@ class Mission
 		};
 		class Item15
 		{
-			dataType="Marker";
-			position[]={3234.6553,153.6004,4278.1333};
-			name="arsenal";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=126;
-			atlOffset=113.9404;
-		};
-		class Item16
-		{
-			dataType="Marker";
-			position[]={3330.448,153.67593,4384.7959};
-			name="arsenal_2";
-			text="@STR_vn_mf_arsenal";
-			type="mil_dot";
-			colorName="ColorPink";
-			id=129;
-			atlOffset=110.68593;
-		};
-		class Item17
-		{
 			dataType="Layer";
 			name="Players";
 			id=193;
 			atlOffset=-29.639999;
 		};
-		class Item18
+		class Item16
 		{
 			dataType="Layer";
 			name="Arsenals";
@@ -1914,7 +1922,7 @@ class Mission
 			id=196;
 			atlOffset=1.6050606;
 		};
-		class Item19
+		class Item17
 		{
 			dataType="Marker";
 			position[]={3322.9866,129.6225,4391.4292};
@@ -1925,7 +1933,7 @@ class Mission
 			id=197;
 			atlOffset=86.632492;
 		};
-		class Item20
+		class Item18
 		{
 			dataType="Marker";
 			position[]={3325.6526,137.98946,4376.6196};
@@ -1937,7 +1945,7 @@ class Mission
 			id=199;
 			atlOffset=94.999451;
 		};
-		class Item21
+		class Item19
 		{
 			dataType="Marker";
 			position[]={3339.7661,136.14734,4378.0962};
@@ -1949,7 +1957,7 @@ class Mission
 			id=200;
 			atlOffset=93.157333;
 		};
-		class Item22
+		class Item20
 		{
 			dataType="Marker";
 			position[]={3190.6536,115.552,4293.521};
@@ -1963,7 +1971,7 @@ class Mission
 			id=201;
 			atlOffset=75.891998;
 		};
-		class Item23
+		class Item21
 		{
 			dataType="Marker";
 			position[]={3337.4041,140.24379,4378.3154};
@@ -1973,7 +1981,7 @@ class Mission
 			id=203;
 			atlOffset=97.253784;
 		};
-		class Item24
+		class Item22
 		{
 			dataType="Marker";
 			position[]={3322.2263,140.55472,4392.8491};
@@ -1984,7 +1992,7 @@ class Mission
 			id=204;
 			atlOffset=97.564713;
 		};
-		class Item25
+		class Item23
 		{
 			dataType="Marker";
 			position[]={3325.7202,118.37007,4379.2417};
@@ -1994,7 +2002,7 @@ class Mission
 			id=206;
 			atlOffset=75.31041;
 		};
-		class Item26
+		class Item24
 		{
 			dataType="Marker";
 			position[]={3235.0828,129.67668,4274.5361};
@@ -2004,7 +2012,7 @@ class Mission
 			id=207;
 			atlOffset=90.001434;
 		};
-		class Item27
+		class Item25
 		{
 			dataType="Marker";
 			position[]={3216.1121,114.29787,4288.0981};
@@ -2014,7 +2022,7 @@ class Mission
 			id=208;
 			atlOffset=74.637863;
 		};
-		class Item28
+		class Item26
 		{
 			dataType="Marker";
 			position[]={3190.7747,104.39438,4293.5083};
@@ -2024,7 +2032,7 @@ class Mission
 			id=209;
 			atlOffset=64.734375;
 		};
-		class Item29
+		class Item27
 		{
 			dataType="Marker";
 			position[]={3206.5876,133.9577,4261.8174};
@@ -2034,7 +2042,7 @@ class Mission
 			id=210;
 			atlOffset=94.297699;
 		};
-		class Item30
+		class Item28
 		{
 			dataType="Marker";
 			position[]={3235.2048,130.47818,4273.3555};
@@ -2046,7 +2054,7 @@ class Mission
 			id=198;
 			atlOffset=90.76059;
 		};
-		class Item31
+		class Item29
 		{
 			dataType="Marker";
 			position[]={3358.7292,137.79372,4318.7036};
@@ -2057,7 +2065,7 @@ class Mission
 			id=216;
 			atlOffset=98.128532;
 		};
-		class Item32
+		class Item30
 		{
 			dataType="Marker";
 			position[]={3355.3123,137.32648,4311.5659};
@@ -2068,14 +2076,14 @@ class Mission
 			id=217;
 			atlOffset=97.622742;
 		};
-		class Item33
+		class Item31
 		{
 			dataType="Layer";
 			name="Vehicles";
 			id=221;
 			atlOffset=-29.639999;
 		};
-		class Item34
+		class Item32
 		{
 			dataType="Layer";
 			name="Rearm Points";
@@ -2326,14 +2334,14 @@ class Mission
 			id=224;
 			atlOffset=0.014087677;
 		};
-		class Item35
+		class Item33
 		{
 			dataType="Layer";
 			name="Vehicles_1";
 			id=251;
 			atlOffset=-29.639999;
 		};
-		class Item36
+		class Item34
 		{
 			dataType="Layer";
 			name="Wreck Bay";
@@ -2778,7 +2786,7 @@ class Mission
 					};
 					id=323;
 					type="Land_vn_canister_ep1";
-					atlOffset=-3.4332275e-005;
+					atlOffset=-3.4332275e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -2977,7 +2985,7 @@ class Mission
 			id=331;
 			atlOffset=-0.01531601;
 		};
-		class Item37
+		class Item35
 		{
 			dataType="Marker";
 			position[]={3318.5298,67.474922,4348.7925};
@@ -2990,7 +2998,7 @@ class Mission
 			id=344;
 			atlOffset=27.804585;
 		};
-		class Item38
+		class Item36
 		{
 			dataType="Group";
 			side="West";
@@ -3184,7 +3192,7 @@ class Mission
 			id=414;
 			atlOffset=0.066204071;
 		};
-		class Item39
+		class Item37
 		{
 			dataType="Group";
 			side="West";
@@ -3378,7 +3386,7 @@ class Mission
 			id=416;
 			atlOffset=0.019699097;
 		};
-		class Item40
+		class Item38
 		{
 			dataType="Group";
 			side="West";
@@ -3570,7 +3578,7 @@ class Mission
 			};
 			id=418;
 		};
-		class Item41
+		class Item39
 		{
 			dataType="Group";
 			side="West";
@@ -3725,7 +3733,7 @@ class Mission
 					};
 					id=421;
 					type="vn_b_men_sf_06";
-					atlOffset=-4.9591064e-005;
+					atlOffset=-4.9591064e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -3762,9 +3770,9 @@ class Mission
 			{
 			};
 			id=420;
-			atlOffset=-4.9591064e-005;
+			atlOffset=-4.9591064e-05;
 		};
-		class Item42
+		class Item40
 		{
 			dataType="Group";
 			side="West";
@@ -3956,7 +3964,7 @@ class Mission
 			};
 			id=422;
 		};
-		class Item43
+		class Item41
 		{
 			dataType="Group";
 			side="West";
@@ -4148,7 +4156,7 @@ class Mission
 			};
 			id=424;
 		};
-		class Item44
+		class Item42
 		{
 			dataType="Group";
 			side="West";
@@ -4340,7 +4348,7 @@ class Mission
 			};
 			id=426;
 		};
-		class Item45
+		class Item43
 		{
 			dataType="Group";
 			side="West";
@@ -4532,7 +4540,7 @@ class Mission
 			};
 			id=428;
 		};
-		class Item46
+		class Item44
 		{
 			dataType="Group";
 			side="West";
@@ -4724,7 +4732,7 @@ class Mission
 			};
 			id=430;
 		};
-		class Item47
+		class Item45
 		{
 			dataType="Group";
 			side="West";
@@ -4916,7 +4924,7 @@ class Mission
 			};
 			id=432;
 		};
-		class Item48
+		class Item46
 		{
 			dataType="Group";
 			side="West";
@@ -5110,7 +5118,7 @@ class Mission
 			id=434;
 			atlOffset=0.033336639;
 		};
-		class Item49
+		class Item47
 		{
 			dataType="Group";
 			side="West";
@@ -5302,7 +5310,7 @@ class Mission
 			};
 			id=436;
 		};
-		class Item50
+		class Item48
 		{
 			dataType="Group";
 			side="West";
@@ -5494,7 +5502,7 @@ class Mission
 			};
 			id=438;
 		};
-		class Item51
+		class Item49
 		{
 			dataType="Group";
 			side="West";
@@ -5686,7 +5694,7 @@ class Mission
 			};
 			id=440;
 		};
-		class Item52
+		class Item50
 		{
 			dataType="Group";
 			side="West";
@@ -5878,7 +5886,7 @@ class Mission
 			};
 			id=442;
 		};
-		class Item53
+		class Item51
 		{
 			dataType="Group";
 			side="West";
@@ -6070,7 +6078,7 @@ class Mission
 			};
 			id=444;
 		};
-		class Item54
+		class Item52
 		{
 			dataType="Group";
 			side="West";
@@ -6262,7 +6270,7 @@ class Mission
 			};
 			id=446;
 		};
-		class Item55
+		class Item53
 		{
 			dataType="Group";
 			side="West";
@@ -6454,7 +6462,7 @@ class Mission
 			};
 			id=448;
 		};
-		class Item56
+		class Item54
 		{
 			dataType="Group";
 			side="West";
@@ -6646,7 +6654,7 @@ class Mission
 			};
 			id=450;
 		};
-		class Item57
+		class Item55
 		{
 			dataType="Group";
 			side="West";
@@ -6838,7 +6846,7 @@ class Mission
 			};
 			id=452;
 		};
-		class Item58
+		class Item56
 		{
 			dataType="Group";
 			side="West";
@@ -6993,7 +7001,7 @@ class Mission
 					};
 					id=455;
 					type="vn_b_men_sf_06";
-					atlOffset=3.8146973e-006;
+					atlOffset=3.8146973e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -7030,9 +7038,9 @@ class Mission
 			{
 			};
 			id=454;
-			atlOffset=3.8146973e-006;
+			atlOffset=3.8146973e-06;
 		};
-		class Item59
+		class Item57
 		{
 			dataType="Group";
 			side="West";
@@ -7224,7 +7232,7 @@ class Mission
 			};
 			id=456;
 		};
-		class Item60
+		class Item58
 		{
 			dataType="Group";
 			side="West";
@@ -7416,7 +7424,7 @@ class Mission
 			};
 			id=458;
 		};
-		class Item61
+		class Item59
 		{
 			dataType="Group";
 			side="West";
@@ -7608,7 +7616,7 @@ class Mission
 			};
 			id=460;
 		};
-		class Item62
+		class Item60
 		{
 			dataType="Group";
 			side="West";
@@ -7800,7 +7808,7 @@ class Mission
 			};
 			id=462;
 		};
-		class Item63
+		class Item61
 		{
 			dataType="Group";
 			side="West";
@@ -7992,7 +8000,7 @@ class Mission
 			};
 			id=464;
 		};
-		class Item64
+		class Item62
 		{
 			dataType="Group";
 			side="West";
@@ -8184,7 +8192,7 @@ class Mission
 			};
 			id=466;
 		};
-		class Item65
+		class Item63
 		{
 			dataType="Group";
 			side="West";
@@ -8376,7 +8384,7 @@ class Mission
 			};
 			id=468;
 		};
-		class Item66
+		class Item64
 		{
 			dataType="Group";
 			side="West";
@@ -8568,7 +8576,7 @@ class Mission
 			};
 			id=470;
 		};
-		class Item67
+		class Item65
 		{
 			dataType="Group";
 			side="West";
@@ -8760,7 +8768,7 @@ class Mission
 			};
 			id=472;
 		};
-		class Item68
+		class Item66
 		{
 			dataType="Group";
 			side="West";
@@ -8952,7 +8960,7 @@ class Mission
 			};
 			id=474;
 		};
-		class Item69
+		class Item67
 		{
 			dataType="Group";
 			side="West";
@@ -9144,7 +9152,7 @@ class Mission
 			};
 			id=476;
 		};
-		class Item70
+		class Item68
 		{
 			dataType="Group";
 			side="West";
@@ -9299,7 +9307,7 @@ class Mission
 					};
 					id=479;
 					type="vn_b_men_sf_06";
-					atlOffset=-1.1444092e-005;
+					atlOffset=-1.1444092e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -9336,9 +9344,9 @@ class Mission
 			{
 			};
 			id=478;
-			atlOffset=-1.1444092e-005;
+			atlOffset=-1.1444092e-05;
 		};
-		class Item71
+		class Item69
 		{
 			dataType="Group";
 			side="West";
@@ -9494,7 +9502,7 @@ class Mission
 					};
 					id=487;
 					type="vn_b_men_sf_06";
-					atlOffset=-2.2888184e-005;
+					atlOffset=-2.2888184e-05;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -9531,9 +9539,9 @@ class Mission
 			{
 			};
 			id=486;
-			atlOffset=-2.2888184e-005;
+			atlOffset=-2.2888184e-05;
 		};
-		class Item72
+		class Item70
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9549,7 +9557,7 @@ class Mission
 			id=557;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item73
+		class Item71
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9566,7 +9574,7 @@ class Mission
 			id=558;
 			type="Land_vn_object_trashcan_01";
 		};
-		class Item74
+		class Item72
 		{
 			dataType="Group";
 			side="East";
@@ -9587,16 +9595,16 @@ class Mission
 					};
 					id=563;
 					type="vn_o_men_nva_07";
-					atlOffset=1.4305115e-006;
+					atlOffset=1.4305115e-06;
 				};
 			};
 			class Attributes
 			{
 			};
 			id=562;
-			atlOffset=1.4305115e-006;
+			atlOffset=1.4305115e-06;
 		};
-		class Item75
+		class Item73
 		{
 			dataType="Layer";
 			name="Light transport spawn #1";
@@ -9667,7 +9675,7 @@ class Mission
 			id=618;
 			atlOffset=0.26150131;
 		};
-		class Item76
+		class Item74
 		{
 			dataType="Layer";
 			name="Light transport spawn #2";
@@ -9738,7 +9746,7 @@ class Mission
 			id=619;
 			atlOffset=0.25;
 		};
-		class Item77
+		class Item75
 		{
 			dataType="Layer";
 			name="Heavy transport spawn #1";
@@ -9811,7 +9819,7 @@ class Mission
 			id=620;
 			atlOffset=0.26326752;
 		};
-		class Item78
+		class Item76
 		{
 			dataType="Layer";
 			name="Heavy transport spawn #2";
@@ -9884,7 +9892,7 @@ class Mission
 			id=621;
 			atlOffset=0.20140457;
 		};
-		class Item79
+		class Item77
 		{
 			dataType="Layer";
 			name="Heavy transport spawn #3";
@@ -9919,7 +9927,7 @@ class Mission
 					};
 					id=577;
 					type="vn_signad_sponsors_f";
-					atlOffset=3.8146973e-006;
+					atlOffset=3.8146973e-06;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -9958,7 +9966,7 @@ class Mission
 			id=622;
 			atlOffset=0.51951218;
 		};
-		class Item80
+		class Item78
 		{
 			dataType="Layer";
 			name="Tank spawn #1";
@@ -10031,7 +10039,7 @@ class Mission
 			id=623;
 			atlOffset=0.25;
 		};
-		class Item81
+		class Item79
 		{
 			dataType="Layer";
 			name="Tank spawn #2";
@@ -10104,7 +10112,7 @@ class Mission
 			id=624;
 			atlOffset=0.25;
 		};
-		class Item82
+		class Item80
 		{
 			dataType="Layer";
 			name="Light fire support spawn #1";
@@ -10177,7 +10185,7 @@ class Mission
 			id=625;
 			atlOffset=0.27933502;
 		};
-		class Item83
+		class Item81
 		{
 			dataType="Layer";
 			name="Patrol spawn #1";
@@ -10250,7 +10258,7 @@ class Mission
 			id=626;
 			atlOffset=0.254879;
 		};
-		class Item84
+		class Item82
 		{
 			dataType="Layer";
 			name="Patrol spawn #2";
@@ -10323,7 +10331,7 @@ class Mission
 			id=627;
 			atlOffset=0.24422836;
 		};
-		class Item85
+		class Item83
 		{
 			dataType="Layer";
 			name="Utility spawn #1";
@@ -10396,7 +10404,7 @@ class Mission
 			id=628;
 			atlOffset=0.2178154;
 		};
-		class Item86
+		class Item84
 		{
 			dataType="Layer";
 			name="Utility spawn #2";
@@ -10469,7 +10477,7 @@ class Mission
 			id=629;
 			atlOffset=0.22459793;
 		};
-		class Item87
+		class Item85
 		{
 			dataType="Layer";
 			name="Utility spawn #3";
@@ -10542,7 +10550,7 @@ class Mission
 			id=630;
 			atlOffset=0.21720505;
 		};
-		class Item88
+		class Item86
 		{
 			dataType="Layer";
 			name="Light air spawn #1";
@@ -10615,7 +10623,7 @@ class Mission
 			id=631;
 			atlOffset=0.021381378;
 		};
-		class Item89
+		class Item87
 		{
 			dataType="Layer";
 			name="Scout air spawn #1";
@@ -10688,7 +10696,7 @@ class Mission
 			id=632;
 			atlOffset=0.067237854;
 		};
-		class Item90
+		class Item88
 		{
 			dataType="Layer";
 			name="Heavy air support spawn #1";
@@ -10761,7 +10769,7 @@ class Mission
 			id=633;
 			atlOffset=0.25;
 		};
-		class Item91
+		class Item89
 		{
 			dataType="Layer";
 			name="Air transport spawn #1";
@@ -10834,7 +10842,7 @@ class Mission
 			id=634;
 			atlOffset=0.072570801;
 		};
-		class Item92
+		class Item90
 		{
 			dataType="Layer";
 			name="Artillery spawn #1";

--- a/maps/vn_the_bra/mission.sqm
+++ b/maps/vn_the_bra/mission.sqm
@@ -20,14 +20,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=713;
+		nextID=742;
 	};
 	class Camera
 	{
-		pos[]={3482.189,125.19694,4428.1924};
-		dir[]={0.77116805,-0.3905654,-0.50280321};
-		up[]={0.32717898,0.92057109,-0.21332233};
-		aside[]={-0.54618192,3.3559627e-07,-0.83770043};
+		pos[]={0,33.930714,-25};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710677,0.70710677};
+		aside[]={0.99999994,0,-0};
 	};
 };
 binarizationWanted=0;
@@ -46,7 +46,6 @@ addons[]=
 	"A3_Structures_F_Items_Tools",
 	"characters_f_vietnam_c",
 	"sounds_f_vietnam_c",
-	"cba_jam_vn",
 	"A3_Misc_F_Helpers",
 	"A3_Modules_F"
 };
@@ -54,7 +53,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=15;
+		items=14;
 		class Item0
 		{
 			className="modules_f_vietnam";
@@ -141,19 +140,12 @@ class AddonsMetaData
 		};
 		class Item12
 		{
-			className="cba_jam_vn";
-			name="Community Base Addons - Joint Ammo Magazines";
-			author="CBA Team";
-			url="https://www.github.com/CBATeam/CBA_A3";
-		};
-		class Item13
-		{
 			className="A3_Misc_F";
 			name="Arma 3 - 3D Aids and Helpers";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item14
+		class Item13
 		{
 			className="A3_Modules_F";
 			name="Arma 3 Alpha - Scripted Modules";
@@ -214,24 +206,6 @@ class CustomAttributes
 				class data
 				{
 					singleType="ARRAY";
-				};
-			};
-		};
-		nAttributes=1;
-	};
-	class Category1
-	{
-		name="Scenario";
-		class Attribute0
-		{
-			property="cba_settings_hasSettingsFile";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					singleType="BOOL";
-					value=1;
 				};
 			};
 		};

--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -37,6 +37,7 @@ class CfgFunctions
 				postinit = 1;
 			};
 			class adv_revive_params {};
+			class arsenals_init {};
 			class init_mission_handlers {};
 		};
 

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -23,13 +23,6 @@ private _arsenals = synchronizedObjects (
 );
 
 {
-	// store an array of nearby trashcans for clients to
-	// initialise the 'Clean Up' action on server join
-	private _trash_cans = (nearestObjects [_x, [], 10, true]) select {
-		typeOf _x isEqualTo "Land_vn_object_trashcan_01"
-	};
-	_x setVariable ["trashcans", _trash_cans];
-
 	// create map markers for arsenal objects
 	_marker = createMarkerLocal [format["vn_mf_arsenal_%1", _forEachIndex], _x];
 	_marker setMarkerTextLocal "Arsenal";

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -31,7 +31,7 @@ private _arsenals = synchronizedObjects (
 	_x setVariable ["trashcans", _trash_cans];
 
 	// create map markers for arsenal objects
-	_marker = createMarkerLocal [format["vn_mf_arsenal_", _forEachIndex], _x];
+	_marker = createMarkerLocal [format["vn_mf_arsenal_%1", _forEachIndex], _x];
 	_marker setMarkerTextLocal "Arsenal";
 	_marker setMarkerTypeLocal "mil_dot";
 	_marker setMarkerColorLocal "ColorPink";

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -19,9 +19,11 @@
 
 diag_log format ["INFO: %1: Loading arsenals ...", _fnc_scriptName];
 
-private _arsenals = synchronizedObjects (
-	allMissionObjects "Logic" select {typeOf _x isEqualTo "vn_module_whitelistedarsenal"}
-);
+// can be multiple WL arsenal modules in the mission
+// also possible to sync different module instances to the same arsenal object
+private _wlModules = allMissionObjects "Logic" select {typeOf _x isEqualTo "vn_module_whitelistedarsenal"};
+private _arsenals = flatten (_wlModules apply {synchronizedObjects _x});
+_arsenals = _arsenals arrayIntersect _arsenals;
 
 {
 	// create map markers for arsenal objects

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -39,5 +39,5 @@ private _arsenals = synchronizedObjects (
 } forEach _arsenals;
 
 missionNamespace setVariable ["vn_mf_arsenals", _arsenals];
-diag_log format ["Loaded %1 arsenals.", _arsenals];
+diag_log format ["Loaded %1 arsenals.", count _arsenals];
 true;

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -36,4 +36,5 @@ _arsenals = _arsenals arrayIntersect _arsenals;
 
 missionNamespace setVariable ["vn_mf_arsenals", _arsenals];
 diag_log format ["INFO: %1: Loaded %2 arsenals.", _fnc_scriptName, count _arsenals];
-true;
+
+true

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -9,10 +9,11 @@
 
 	Parameter(s): none
 
-	Returns: nothing
+	Returns:
+		true when executed successfully
 
 	Example(s):
-		Not called directly
+		call vn_mf_fnc_arsenals_init;
 */
 
 

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -18,16 +18,9 @@
 
 diag_log "Loading arsenals ...";
 
-private _allLogics = allMissionObjects "Logic";
-
-private _wlArsenalLogicIdx = _allLogics findIf {
-	private _allVars = allVariables _x;
-	// all three of these are present as non-BI variables in the WL Arsenals module
-	// found with `(allMissionObjects "Logic") apply { allVariables _x }`
-	"scope" in _allVars && "rank" in _allVars && "side" in _allVars;
-};
-
-private _arsenals = synchronizedObjects (_allLogics select _wlArsenalLogicIdx);
+private _arsenals = synchronizedObjects (
+	allMissionObjects "Logic" select {typeOf _x isEqualTo "vn_module_whitelistedarsenal"}
+);
 
 {
 	// store an array of nearby trashcans for clients to

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -17,7 +17,7 @@
 */
 
 
-diag_log "Loading arsenals ...";
+diag_log format ["INFO: %1: Loading arsenals ...", _fnc_scriptName];
 
 private _arsenals = synchronizedObjects (
 	allMissionObjects "Logic" select {typeOf _x isEqualTo "vn_module_whitelistedarsenal"}
@@ -33,5 +33,5 @@ private _arsenals = synchronizedObjects (
 } forEach _arsenals;
 
 missionNamespace setVariable ["vn_mf_arsenals", _arsenals];
-diag_log format ["Loaded %1 arsenals.", count _arsenals];
+diag_log format ["INFO: %1: Loaded %2 arsenals.", _fnc_scriptName, count _arsenals];
 true;

--- a/mission/functions/core/init/fn_arsenals_init.sqf
+++ b/mission/functions/core/init/fn_arsenals_init.sqf
@@ -1,0 +1,50 @@
+/*
+	File: fn_arsenals_init.sqf
+	Author: Savage Game Design
+	Public: No
+
+	Description:
+		Sets up arsenals with Arsenal map markers
+		and finds nearby trashcans to initialise when player joins
+
+	Parameter(s): none
+
+	Returns: nothing
+
+	Example(s):
+		Not called directly
+*/
+
+
+diag_log "Loading arsenals ...";
+
+private _allLogics = allMissionObjects "Logic";
+
+private _wlArsenalLogicIdx = _allLogics findIf {
+	private _allVars = allVariables _x;
+	// all three of these are present as non-BI variables in the WL Arsenals module
+	// found with `(allMissionObjects "Logic") apply { allVariables _x }`
+	"scope" in _allVars && "rank" in _allVars && "side" in _allVars;
+};
+
+private _arsenals = synchronizedObjects (_allLogics select _wlArsenalLogicIdx);
+
+{
+	// store an array of nearby trashcans for clients to
+	// initialise the 'Clean Up' action on server join
+	private _trash_cans = (nearestObjects [_x, [], 10, true]) select {
+		typeOf _x isEqualTo "Land_vn_object_trashcan_01"
+	};
+	_x setVariable ["trashcans", _trash_cans];
+
+	// create map markers for arsenal objects
+	_marker = createMarkerLocal [format["vn_mf_arsenal_", _forEachIndex], _x];
+	_marker setMarkerTextLocal "Arsenal";
+	_marker setMarkerTypeLocal "mil_dot";
+	_marker setMarkerColorLocal "ColorPink";
+	_marker setMarkerAlpha 1;
+} forEach _arsenals;
+
+missionNamespace setVariable ["vn_mf_arsenals", _arsenals];
+diag_log format ["Loaded %1 arsenals.", _arsenals];
+true;

--- a/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
+++ b/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
@@ -16,30 +16,39 @@
 		call vn_mf_fnc_arsenal_trash_cleanup_init;
 */
 
+
 private _arsenals = missionNamespace getVariable ["vn_mf_arsenals", []];
 
-_arsenals apply {
-	private _trashcans = _x getVariable ["trashcans", []];
-	_trashcans apply {
-		_x addAction
-		[
-			"Clean Up",
-			{
-				params ["_target", "_caller", "_actionId", "_arguments"];
-				["arsenalcleanup", [_target]] call para_c_fnc_call_on_server;
-			},
-			nil,
-			1.5,
-			true,
-			true,
-			"",
-			"true",
-			5,
-			false,
-			"",
-			""
-		];
-	};
+if (count _arsenals isEqualTo 0) exitWith {
+	diag_log format ["WARN: %1: No arsenals initialised, cannot setup trashcan cleanup addAction."];
+	nil;
 };
+
+_arsenals
+	apply {
+		// consider a 'trash can' to be any non WLA module objects synchronized to the arsenal object
+		// (mission makers can then use other classes if they want to)
+		(synchronizedObjects _x)
+			select {typeOf _x isNotEqualTo "vn_module_whitelistedarsenal"}
+			apply {
+				_x addAction [
+					"Clean Up",
+					{
+						params ["_target", "_caller", "_actionId", "_arguments"];
+						["arsenalcleanup", [_target]] call para_c_fnc_call_on_server;
+					},
+					nil,
+					1.5,
+					true,
+					true,
+					"",
+					"true",
+					5,
+					false,
+					"",
+					""
+				];
+			};
+	};
 
 true;

--- a/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
+++ b/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
@@ -10,26 +10,29 @@
 		None
 
 	Returns:
-		None
+		true when executed successfully, nil on error.
 
 	Example(s):
 		call vn_mf_fnc_arsenal_trash_cleanup_init;
 */
 
+diag_log format ["INFO: %1: Loading trash cans ...", _fnc_scriptName];
 
 private _arsenals = missionNamespace getVariable ["vn_mf_arsenals", []];
 
-if (count _arsenals isEqualTo 0) exitWith {
-	diag_log format ["WARN: %1: No arsenals initialised, cannot setup trashcan cleanup addAction."];
+if (_arsenals isEqualTo []) exitWith {
+	diag_log format [
+		"WARN: %1: No mike force arsenals initialised, cannot init trash cans.",
+		_fnc_scriptName,
+	];
 	nil;
 };
 
 _arsenals
 	apply {
-		// consider a 'trash can' to be any non WLA module objects synchronized to the arsenal object
-		// (mission makers can then use other classes if they want to)
-		(synchronizedObjects _x)
-			select {typeOf _x isNotEqualTo "vn_module_whitelistedarsenal"}
+		// find nearby trash can objects (within 10m) and add the clean up action
+		(nearestObjects [_x, [], 10, true])
+			select {typeOf _x isEqualTo "Land_vn_object_trashcan_01"}
 			apply {
 				_x addAction [
 					"Clean Up",
@@ -50,5 +53,7 @@ _arsenals
 				];
 			};
 	};
+
+diag_log format ["INFO: %1: Trash cans loaded.", _fnc_scriptName];
 
 true;

--- a/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
+++ b/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
@@ -1,41 +1,45 @@
 /*
-    File: fn_arsenal_trash_cleanup_init.sqf
-    Author: Savage Game Design
-    Public: Yes
+	File: fn_arsenal_trash_cleanup_init.sqf
+	Author: Savage Game Design
+	Public: Yes
 
-    Description:
-        Called to initialise the trashcans on the map near arsenals.
+	Description:
+		Called to initialise the trashcans on the map near arsenals.
 
-    Parameter(s):
-        None
+	Parameter(s):
+		None
 
-    Returns:
-        None
+	Returns:
+		None
 
-    Example(s):
-        call vn_mf_fnc_arsenal_trash_cleanup_init;
+	Example(s):
+		call vn_mf_fnc_arsenal_trash_cleanup_init;
 */
 
-private _arsenals = allMapMarkers select {_x find "arsenal" isEqualTo 0};
+private _arsenals = missionNamespace getVariable ["vn_mf_arsenals", []];
 
-{
-	private _trashCan = missionNamespace getVariable [format["arsenal_cleanup_%1",_forEachIndex], objNull];
-	_trashCan addAction
-	[
-		"Clean Up",
-		{
-			params ["_target", "_caller", "_actionId", "_arguments"];
-			["arsenalcleanup", [_target]] call para_c_fnc_call_on_server;
-		},
-		nil,
-		1.5,
-		true,
-		true,
-		"",
-		"true",
-		5,
-		false,
-		"",
-		""
-	];
-} forEach _arsenals;
+_arsenals apply {
+	private _trashcans = _x getVariable ["trashcans", []];
+	_trashcans apply {
+		_x addAction
+		[
+			"Clean Up",
+			{
+				params ["_target", "_caller", "_actionId", "_arguments"];
+				["arsenalcleanup", [_target]] call para_c_fnc_call_on_server;
+			},
+			nil,
+			1.5,
+			true,
+			true,
+			"",
+			"true",
+			5,
+			false,
+			"",
+			""
+		];
+	};
+};
+
+true;

--- a/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
+++ b/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
@@ -23,7 +23,7 @@ private _arsenals = missionNamespace getVariable ["vn_mf_arsenals", []];
 if (_arsenals isEqualTo []) exitWith {
 	diag_log format [
 		"WARN: %1: No mike force arsenals initialised, cannot init trash cans.",
-		_fnc_scriptName,
+		_fnc_scriptName
 	];
 	nil;
 };

--- a/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
+++ b/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
@@ -25,7 +25,7 @@ if (_arsenals isEqualTo []) exitWith {
 		"WARN: %1: No mike force arsenals initialised, cannot init trash cans.",
 		_fnc_scriptName
 	];
-	nil;
+	nil
 };
 
 _arsenals
@@ -56,4 +56,4 @@ _arsenals
 
 diag_log format ["INFO: %1: Trash cans loaded.", _fnc_scriptName];
 
-true;
+true

--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -139,6 +139,9 @@ enableenvironment [[false,true] select _ambientlife,[false,true] select _ambient
 //Set up respawn points.
 [] call vn_mf_fnc_respawn_points_init;
 
+// setup arsenals
+[] call vn_mf_fnc_arsenals_init;
+
 // start scheduler
 diag_log "VN MikeForce: Starting scheduler";
 [] call para_g_fnc_scheduler_subsystem_init;


### PR DESCRIPTION
Was writing up the wiki and felt very weird having a dance between having N `arsenal_cleanup_n` trash cans, where `N` must match the index of the arsenal (what if someone wants to put down two trash cans for one arsenal?!).

This adds some server side initialisation logic to make life simpler
- Finds the white listed arsenal module logics
- Any object synchronised to the logic is considered an 'arsenal'
- Add pink map markers for all arsenals
- Save arsenals `missionNamespace setVariable ["vn_mf_arsenals", _arsenals]`

When a player joins, we can just load trash cans by finding relevant objects within 10m of the init'd arsenals instead of having to find different map markers and resolve the trashcans based on indexes of map markers.

--

TODO
- [x] Remove arsenal markers from each map (will be automatically created on server init)
