### PR TITLE
VehSpawn: add queued status to mitigate duplicate spawns (race condition)

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -341,6 +341,7 @@ class CfgFunctions
 			class veh_asset_respawn {};
 			class veh_asset_respawn_job {};
 			class veh_asset_set_active {};
+			class veh_asset_set_queued {};
 			class veh_asset_set_disabled {};
 			class veh_asset_set_global_variable {};
 			class veh_asset_set_global_variables {};

--- a/mission/functions/systems/vehicle_asset_manager/client/fn_veh_asset_describe_status.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/client/fn_veh_asset_describe_status.sqf
@@ -27,6 +27,7 @@ if (isNil "_spawnPoint") exitWith { "" };
 private _vehicle = _spawnPoint getOrDefault ["currentVehicle", objNull];
 private _vehicleType = typeOf _vehicle;
 private _vehicleName = getText (configFile >> "CfgVehicles" >> _vehicleType >> "displayName");
+if (_vehicleName isEqualTo "") then {_vehicleName = "vehicle"};
 
 private _status = _spawnPoint getOrDefault ["status", createHashMap];
 private _state = _status getOrDefault ["state", "UNKNOWN"];
@@ -43,29 +44,13 @@ private _fnc_getTimeRemaining = {
 	format ["%1 seconds", _seconds];
 };
 
-if (_state isEqualTo "IDLE") exitWith {
-	format ["%1 is currently deployed and not in use.", _vehicleName]
+switch (_state) do {
+	case "IDLE": { format ["%1 is currently deployed and not in use.", _vehicleName] };
+	case "QUEUED": { format ["The %1 is in the respawn queue and should be created within %2", _vehicleName, call _fnc_getTimeRemaining] };
+	case "REPAIRING": { format ["The %1 is currently being repaired, and will be sent to the respawn queue in %2.", _vehicleName, call _fnc_getTimeRemaining] };
+	case "RESPAWNING": { format ["The %1 is currently respawning, and will be sent to the respawn queue in %2.", _vehicleName, call _fnc_getTimeRemaining] };
+	case "WRECKED": { format ["The %1 is currently wrecked. The wreck needs bringing to a wreck recovery point at the main base or a FOB.", _vehicleName] };
+	case "DISABLED": { format ["The %1 is currently deployed. However, it's disabled and needs repairs from an engineer.", _vehicleName] };
+	case "ACTIVE": { format ["The %1 is currently deployed and in use.", _vehicleName] };
+	default { "The current state of this spawn point is unknown." };
 };
-
-if (_state isEqualTo "REPAIRING") exitWith {
-	format ["The vehicle is currently being repaired, and will be finished in %1.", call _fnc_getTimeRemaining];
-};
-
-if (_state isEqualTo "RESPAWNING") exitWith {
-	format ["The vehicle is currently respawning, and will be finished in %1.", call _fnc_getTimeRemaining];
-};
-
-if (_state isEqualTo "WRECKED") exitWith {
-	format ["The %1 is currently wrecked. The wreck needs bringing to a wreck recovery point at the main base or a FOB.", _vehicleName];
-};
-
-if (_state isEqualTo "DISABLED") exitWith {
-	format ["The %1 is currently deployed. However, it's disabled and needs repairs from an engineer.", _vehicleName];
-};
-
-if (_state isEqualTo "ACTIVE") exitWith {
-	format ["The %1 is currently deployed and in use.", _vehicleName];
-};
-
-
-"The current state of this spawn point is unknown."

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_process_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_process_spawn_point.sqf
@@ -44,7 +44,7 @@ if(!alive _vehicle) then {
 };
 
 //Vehicle is dead, and hasn't be transitioned to a "DEAD" state.
-if (!alive _vehicle && !((_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING", "WRECKED"])) then {
+if (!alive _vehicle && !((_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING", "WRECKED", "QUEUED"])) then {
 	if (_respawnType == "WRECK") exitWith {
 		[_spawnPoint] call vn_mf_fnc_veh_asset_set_wrecked;
 	};
@@ -155,14 +155,16 @@ if ((_spawnPoint get "status" get "state") == "IDLE") then {
 };
 
 //Update marker position if it exists, and it's been too long.
-if (_doMarkerUpdate && !((_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING"])) then {
+if (_doMarkerUpdate && !((_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING", "QUEUED"])) then {
 	[_spawnPoint] call vn_mf_fnc_veh_asset_marker_update_position;
 };
 
-//Check if a vehicle should be respawned
+//Check if a vehicle should be queued for respawning
+// guarantee delivery exactly once to avoid attempting multiple vehicle spawns and lots of explosions.
 if (
 	(_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING"] && 
 	{(_spawnPoint get "status" getOrDefault ["finishesAt", 0]) < serverTime}
 ) then {
 	vn_mf_spawn_points_to_respawn pushBackUnique (_spawnPoint get "id");
+	[_spawnPoint] call vn_mf_fnc_veh_asset_set_queued;
 };

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_set_queued.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_set_queued.sqf
@@ -1,0 +1,21 @@
+/*
+	File: fn_veh_asset_set_queued.sqf
+	Author: Savage Game Design
+	Public: No
+	Description:
+		Marks the spawn point into queued satus -- we're going to be respawning the vehicle shortly.
+	Parameter(s):
+		_spawnPoint - Spawn point whose vehicle should be set as queued [HashMap]
+	Returns: nothing
+	Example(s): none
+*/
+
+params ["_spawnPoint"];
+
+[_spawnPoint, "status", createHashMapFromArray [
+	["state", "QUEUED"], 
+	["finishesAt", serverTime + 2 +  count vn_mf_spawn_points_to_respawn],
+	["lastChanged", serverTime]
+]] call vn_mf_fnc_veh_asset_set_global_variable;
+
+[_spawnPoint] call vn_mf_fnc_veh_asset_marker_delete;

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_set_queued.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_set_queued.sqf
@@ -18,4 +18,4 @@ params ["_spawnPoint"];
 	["lastChanged", serverTime]
 ]] call vn_mf_fnc_veh_asset_set_global_variable;
 
-[_spawnPoint] call vn_mf_fnc_veh_asset_marker_delete;
+[_spawnPoint] call vn_mf_fnc_veh_asset_marker_delete

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_set_queued.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_set_queued.sqf
@@ -18,4 +18,4 @@ params ["_spawnPoint"];
 	["lastChanged", serverTime]
 ]] call vn_mf_fnc_veh_asset_set_global_variable;
 
-[_spawnPoint] call vn_mf_fnc_veh_asset_marker_delete
+[_spawnPoint] call vn_mf_fnc_veh_asset_marker_delete;


### PR DESCRIPTION
A race condition can occur here because delivery of spawn point IDs to the `vn_mf_spawn_points_to_respawn` is not guaranteed to occur exactly one for each request.

This can result in a vehicle double spawning if a server is slow to spawn the object, as multiple copies of the same spawn point ID can be popped from the `vn_mf_spawn_points_to_respawn` array and a new `spawn` is created to respawn the same vehicle.

(had to fix this pretty sharpish previously after migrating onto 1.00.3 vehicle spawners)

#178 will need updating if this is merged first (and vice versa).