### PR TITLE
VehSpawn: Ignore unavailable classes when loading vehicle configs.

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_get_spawn_point_info_from_config.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_get_spawn_point_info_from_config.sqf
@@ -64,15 +64,15 @@ private _categoryConfigs = "true" configClasses (_config >> "categories");
         };
 
         _categoryVehicles = _categoryVehicles select {(_excludeTags - (_x get "tags")) isNotEqualTo []};
+
     } forEach (_category get "exclude");
 
-    private _categoryVehicleClasses = _categoryVehicles apply {_x get "classname"};
-
     _category set ["vehicles", _categoryVehicles];
-    _vehicles append (_categoryVehicleClasses);
+    _vehicles append (_categoryVehicles apply {_x get "classname"});
 } forEach _categoryConfigs;
 
-_spawnPointInfo set ["categories", _categories];
+// only add categories which actually have vehicle options (too many excludes/vehicle's mod not loaded)
+_spawnPointInfo set ["categories", _categories select {(_x getOrDefault ["vehicles", []]) isNotEqualTo []}];
 _spawnPointInfo set ["vehicles", keys (_vehicles createHashMapFromArray [])];
 
-_spawnPointInfo
+_spawnPointInfo;

--- a/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_get_spawn_point_info_from_config.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_get_spawn_point_info_from_config.sqf
@@ -71,8 +71,11 @@ private _categoryConfigs = "true" configClasses (_config >> "categories");
     _vehicles append (_categoryVehicles apply {_x get "classname"});
 } forEach _categoryConfigs;
 
-// only add categories which actually have vehicle options (too many excludes/vehicle's mod not loaded)
-_spawnPointInfo set ["categories", _categories select {(_x getOrDefault ["vehicles", []]) isNotEqualTo []}];
+_spawnPointInfo set [
+    "categories",
+    // exclude categories with zero vehicles after filtering
+    _categories select {(_x getOrDefault ["vehicles", []]) isNotEqualTo []}
+];
 _spawnPointInfo set ["vehicles", keys (_vehicles createHashMapFromArray [])];
 
 _spawnPointInfo;

--- a/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_get_spawn_point_info_from_config.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_get_spawn_point_info_from_config.sqf
@@ -78,4 +78,4 @@ _spawnPointInfo set [
 ];
 _spawnPointInfo set ["vehicles", keys (_vehicles createHashMapFromArray [])];
 
-_spawnPointInfo;
+_spawnPointInfo

--- a/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_load_vehicle_configs.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_load_vehicle_configs.sqf
@@ -25,15 +25,43 @@ if !(isNil "_vehicleList") exitWith {
 };
 
 private _config = missionConfigFile >> "gamemode" >> "vehicle_respawn_info" >> "vehicles";
-
 private _vehicleConfigs = "true" configClasses _config;
-private _vehicles = _vehicleConfigs apply {
+
+
+/*
+check class is available in the mission (has the mod containing the vehicle class been loaded?)
+
+example without nickel steel loaded:
+21:45:36 "WARN: vn_mf_fnc_veh_asset_load_vehicle_configs: 6 vehicle classnames in 'vehicle_respawn_info' do not exist in 'CfgVehicles' (missing mod?)."
+21:45:36 "WARN: vn_mf_fnc_veh_asset_load_vehicle_configs: classnames of vehicles missing in 'CfgVehicles': vnx_b_air_ac119_01_01 / vnx_b_air_ac119_02_01 / vnx_b_air_ac119_02_02 / vnx_b_air_ac119_03_01 / vnx_b_air_ac119_03_02 / vnx_b_air_ac119_04_01"
+21:45:36 "INFO: vn_mf_fnc_veh_asset_load_vehicle_configs: 114 valid vehicle classes loaded."
+
+*/
+
+private _missingVehs = _vehicleConfigs select {!isClass (configFile >> "CfgVehicles" >> (configName _x))};
+if (count _missingVehs > 0) then {
+	// TODO: Simplify `para_g_fnc_log` and switch existing `diag_log format` calls over to it.
+	diag_log format [
+		"WARN: %1: %2 vehicle classnames in 'vehicle_respawn_info' do not exist in 'CfgVehicles' (missing mod?).",
+		_fnc_scriptName,
+		count _missingVehs
+	];
+	diag_log format [
+		"WARN: %1: classnames of vehicles missing in 'CfgVehicles': %2",
+		_fnc_scriptName,
+		_missingVehs apply {configName _x} joinString "/"
+	];
+};
+
+private _validVehs = _vehicleConfigs - _missingVehs;
+diag_log format ["INFO: %1: %2 valid vehicle classes loaded.", _fnc_scriptName, count _validVehs];
+
+private _vehicles = (_vehicleConfigs - _missingVehs) apply {
 	createHashMapFromArray [
 		["classname", configName _x],
 		["tags", getArray (_x >> 'tags')]
 	]
 };
-
 
 private _vehiclesByTag = createHashMap;
 

--- a/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_load_vehicle_configs.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/global/fn_veh_asset_load_vehicle_configs.sqf
@@ -56,7 +56,7 @@ if (count _missingVehs > 0) then {
 private _validVehs = _vehicleConfigs - _missingVehs;
 diag_log format ["INFO: %1: %2 valid vehicle classes loaded.", _fnc_scriptName, count _validVehs];
 
-private _vehicles = (_vehicleConfigs - _missingVehs) apply {
+private _vehicles = _validVehs apply {
 	createHashMapFromArray [
 		["classname", configName _x],
 		["tags", getArray (_x >> 'tags')]

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_3DEN_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_3DEN_spawn_point.sqf
@@ -37,6 +37,7 @@ if (_spawnObjectIndex > -1) then {
 
 private _spawnPointObjects = _synchronizedObjects select {!(_x isKindOf "Helper_Base_F")};
 
+// WARN: see note in `vn_mf_fnc_veh_asset_add_spawn_point` before using result of this function.
 [_spawnPointObjects select 0, _spawnPointSettings, _spawnLocationObject, _this param [1]] call vn_mf_fnc_veh_asset_add_spawn_point;
 
 deleteVehicle this;

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_add_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_add_spawn_point.sqf
@@ -39,7 +39,7 @@ if (_spawnPointSettings isEqualType "") then {
 // can occur if spawn point exclusively provides access to a mod's vehicles, but the mod isn't loaded.
 // NOTE: calling function `vn_mf_fnc_veh_asset_3DEN_spawn_point` doesn't use this function's result (yet).
 if (count (_spawnPointSettings getOrDefault ["categories", createHashMap]) isEqualTo 0) exitWith {
-	diag_log format ["WARN: %1: No categories for spawn point: objPos=%2", _fnc_scriptName, _spawnLocation];
+	diag_log format ["WARN: %1: Disabling spawn point as no categories data found: objPos=%2", _fnc_scriptName, _spawnLocation];
 	createHashMap;
 };
 

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_add_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_add_spawn_point.sqf
@@ -27,12 +27,20 @@ if (_obj getVariable ["veh_asset_isSpawnPoint", false]) exitWith {
 	diag_log format ["VN MikeForce: [WARNING] Attempting to make object a vehicle spawn point twice: %1 at %2", typeOf _obj, getPos _obj];
 };
 
+if (_spawnLocation isEqualType objNull) then {
+	_spawnLocation = [getPosASL _spawnLocation, getDir _spawnLocation];
+};
+
 if (_spawnPointSettings isEqualType "") then {
 	_spawnPointSettings = [missionConfigFile >> "gamemode" >> "vehicle_respawn_info" >> "spawn_point_types" >> _spawnPointSettings] call vn_mf_fnc_veh_asset_get_spawn_point_info_from_config;
 };
 
-if (_spawnLocation isEqualType objNull) then {
-	_spawnLocation = [getPosASL _spawnLocation, getDir _spawnLocation];
+// players won't be able to do anything with this spawn point if no categories exist.
+// can occur if spawn point exclusively provides access to a mod's vehicles, but the mod isn't loaded.
+// NOTE: calling function `vn_mf_fnc_veh_asset_3DEN_spawn_point` doesn't use this function's result (yet).
+if (count (_spawnPointSettings getOrDefault ["categories", createHashMap]) isEqualTo 0) exitWith {
+	diag_log format ["WARN: %1: No categories for spawn point: objPos=%2", _fnc_scriptName, _spawnLocation];
+	createHashMap;
 };
 
 // This allows this function to be called even if the system isn't initialised yet.


### PR DESCRIPTION
Handles the case where Nickel Steel classnames exist in vehicle spawner configs, but server isn't running Nickel Steel.