### PR TITLE
ZoneMarker: Use zone stringtable name entries for pop up zone info display

### DIFF
--- a/mission/functions/core/ui/zone_marker/fn_zone_marker_captured_zone_info.sqf
+++ b/mission/functions/core/ui/zone_marker/fn_zone_marker_captured_zone_info.sqf
@@ -17,4 +17,4 @@
 */
 params ["_marker"];
 //returns the string table entry
-[format ["%1 [Captured]", [_marker] call vn_mf_fnc_zone_marker_to_name]];
+[format ["%1 [Captured]", [_marker] call vn_mf_fnc_zone_marker_to_name]]

--- a/mission/functions/core/ui/zone_marker/fn_zone_marker_captured_zone_info.sqf
+++ b/mission/functions/core/ui/zone_marker/fn_zone_marker_captured_zone_info.sqf
@@ -16,32 +16,5 @@
         ["zone_locationName"] call vn_mf_fnc_zone_marker_captured_zone_info;
 */
 params ["_marker"];
-
-private _typeStart = (_marker find "_") + 1;
-// If no type starter display the raw marker variable. Check for 0 because we've added 1 to the find call.
-if (_typeStart == 0) exitWith {_marker};
-
-private _type = _marker select [0, _typeStart];
-
-// If this somehow gets called on a marker that isin't a zone display the raw marker variable
-if (_type != "zone_") exitWith {_marker};
-
-// Split to allow for spaces
-private _zoneName = _marker splitString "_";
-// Trim marker type
-_zoneName deleteAt 0;
-// Check if spaces are required
-private _splitCheck = count _zoneName;
-// If spaces are requried, add them, else convert ARRAY to STRING to allow data to be pushed to show info function
-if (_splitCheck > 1) then {
-  _zoneName = _zoneName joinString " ";
-} else {
-  _zoneName = _zoneName select 0;
-};
-// Capitalize name
-private _zoneName = toUpper _zoneName;
-// Define info to show
-private _info = [
-    _zoneName
-];
-_info
+//returns the string table entry
+[format ["%1 (Captured)", [_marker] call vn_mf_fnc_zone_marker_to_name]];

--- a/mission/functions/core/ui/zone_marker/fn_zone_marker_captured_zone_info.sqf
+++ b/mission/functions/core/ui/zone_marker/fn_zone_marker_captured_zone_info.sqf
@@ -17,4 +17,4 @@
 */
 params ["_marker"];
 //returns the string table entry
-[format ["%1 (Captured)", [_marker] call vn_mf_fnc_zone_marker_to_name]];
+[format ["%1 [Captured]", [_marker] call vn_mf_fnc_zone_marker_to_name]];

--- a/mission/functions/core/ui/zone_marker/fn_zone_marker_hostile_zone_info.sqf
+++ b/mission/functions/core/ui/zone_marker/fn_zone_marker_hostile_zone_info.sqf
@@ -17,4 +17,4 @@
 */
 params ["_marker"];
 //returns the string table entry
-[format ["%1 (Hostile)", [_marker] call vn_mf_fnc_zone_marker_to_name]];
+[format ["%1 [Hostile]", [_marker] call vn_mf_fnc_zone_marker_to_name]];

--- a/mission/functions/core/ui/zone_marker/fn_zone_marker_hostile_zone_info.sqf
+++ b/mission/functions/core/ui/zone_marker/fn_zone_marker_hostile_zone_info.sqf
@@ -16,32 +16,5 @@
         ["zone_locationName"] call vn_mf_fnc_zone_marker_hostile_zone_info;
 */
 params ["_marker"];
-
-private _typeStart = (_marker find "_") + 1;
-// If no type starter display the raw marker variable. Check for 0 because we've added 1 to the find call.
-if (_typeStart == 0) exitWith {_marker};
-
-private _type = _marker select [0, _typeStart];
-
-// If this somehow gets called on a marker that isin't a zone display the raw marker variable
-if (_type != "zone_") exitWith {_marker};
-
-// Split to allow for spaces
-private _zoneName = _marker splitString "_";
-// Trim marker type
-_zoneName deleteAt 0;
-// Check if spaces are required
-private _splitCheck = count _zoneName;
-// If spaces are requried, add them, else convert ARRAY to STRING to allow data to be pushed to show info function
-if (_splitCheck > 1) then {
-  _zoneName = _zoneName joinString " ";
-} else {
-  _zoneName = _zoneName select 0;
-};
-// Capitalize name
-private _zoneName = toUpper _zoneName;
-// Define info to show
-private _info = [
-    _zoneName
-];
-_info
+//returns the string table entry
+[format ["%1 (Hostile)", [_marker] call vn_mf_fnc_zone_marker_to_name]];

--- a/mission/functions/core/ui/zone_marker/fn_zone_marker_hostile_zone_info.sqf
+++ b/mission/functions/core/ui/zone_marker/fn_zone_marker_hostile_zone_info.sqf
@@ -17,4 +17,4 @@
 */
 params ["_marker"];
 //returns the string table entry
-[format ["%1 [Hostile]", [_marker] call vn_mf_fnc_zone_marker_to_name]];
+[format ["%1 [Hostile]", [_marker] call vn_mf_fnc_zone_marker_to_name]]


### PR DESCRIPTION
Previously these scripts would parse the zone map marker to try and work out the name for the zone -- either through the marker text, which would need to be filled in manually, or by parsing out the `zone_*` marker name.

Much simpler to look up the string table entries for zone names. 

Has the benefit of making zone names consistent across the UI (can include accenting!) and means we only need to write zone names once (in string table file).

![20B2D3~1](https://github.com/user-attachments/assets/e47414d3-7655-4607-8043-859ebe683bd6)

![20769D~1](https://github.com/user-attachments/assets/261e7bc3-5360-4a6e-b39f-1d2373ed52a6)

