### PR TITLE
Fix: Stringtable: Missing zone names (CLN/Altis/Bra)

### DIFF
--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -1570,6 +1570,27 @@
       <Key ID="STR_vn_mf_zone_ling_ho">
         <Original>Ling Ho</Original>
       </Key>
+      <Key ID="STR_vn_mf_zone_nodal_lho">
+        <Original>Nodal Lho</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_plain_of_jars">
+        <Original>Plain of Jars</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_bru_village">
+        <Original>Bru Village</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_son_tay">
+        <Original>Son Tay</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_gia_lam_airbase">
+        <Original>Gia Lam Airbase</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_hanoi_city">
+        <Original>Hanoi City</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_fob_mai_loc">
+        <Original>FOB Mai Loc</Original>
+      </Key>
     </Container>
     <Container name="ZoneName_khe_sanh">
       <Key ID="STR_vn_mf_zone_khe_sanh">

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -1745,6 +1745,15 @@
       <Key ID="STR_vn_mf_zone_southeastern_supply_depot">
         <Original>Southeastern Supply Depot</Original>
       </Key>
+      <Key ID="STR_vn_mf_zone_nva_pow_camp">
+        <Original>NVA POW Camp</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_ban_onglouan">
+        <Original>Ban Onglouan</Original>
+      </Key>
+      <Key ID="STR_vn_mf_zone_ban_chom">
+        <Original>Ban Chom</Original>
+      </Key>
     </Container>
   </Package>
 </Project>

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -1496,6 +1496,9 @@
       <Key ID="STR_vn_mf_zone_aggelochori">
         <Original>Aggelochori</Original>
       </Key>
+      <Key ID="STR_vn_mf_zone_galati">
+        <Original>Galati</Original>
+      </Key>
     </Container>
     <Container name="Zone_Name_Cam_Lao">
       <Key ID="STR_vn_mf_zone_ban_hoang">


### PR DESCRIPTION
```
0:39:08 String STR_vn_mf_zone_nodal_lho not found
0:39:08 String STR_vn_mf_zone_plain_of_jars not found
0:39:08 String STR_vn_mf_zone_bru_village not found
0:39:08 String STR_vn_mf_zone_son_tay not found
0:39:08 String STR_vn_mf_zone_gia_lam_airbase not found
0:39:08 String STR_vn_mf_zone_hanoi_city not found
0:39:08 String STR_vn_mf_zone_fob_mai_loc not found
```
^ fixes this and also means #212 will fully work on all maps

TODO
- [x] check other maps for missing zone names